### PR TITLE
Première version du teamkilltracker

### DIFF
--- a/Alliance.Client/Extensions/AdminMenu/Handlers/AdminMenuHandler.cs
+++ b/Alliance.Client/Extensions/AdminMenu/Handlers/AdminMenuHandler.cs
@@ -15,6 +15,7 @@ namespace Alliance.Client.Extensions.AdminMenu.Handlers
         {
             reg.Register<AdminServerLog>(HandleLogMessage);
             reg.Register<SendNotification>(HandleNotification);
+            reg.Register<TeamKillTrackerLog>(HandleTeamKillTrackerLog);
         }
 
         public void HandleNotification(SendNotification notification)
@@ -36,6 +37,11 @@ namespace Alliance.Client.Extensions.AdminMenu.Handlers
         public void HandleLogMessage(AdminServerLog logger)
         {
             AdminInstance.UpdateServerMessage(new ServerMessageVM(logger.LogMessage, logger.Color));
+        }
+
+        public void HandleTeamKillTrackerLog(TeamKillTrackerLog data)
+        {
+            AdminInstance.UpdateTeamKillTracker(data.TeamDamageByPlayer);
         }
     }
 }

--- a/Alliance.Client/Extensions/AdminMenu/ViewModels/AdminInstance.cs
+++ b/Alliance.Client/Extensions/AdminMenu/ViewModels/AdminInstance.cs
@@ -1,4 +1,5 @@
-﻿using TaleWorlds.Library;
+﻿using System.Collections.Generic;
+using TaleWorlds.Library;
 
 namespace Alliance.Client.Extensions.AdminMenu.ViewModels
 {
@@ -34,6 +35,14 @@ namespace Alliance.Client.Extensions.AdminMenu.ViewModels
             if (_instance != null)
             {
                 _instance.ServerMessage = _serverMessage;
+            }
+        }
+
+        public static void UpdateTeamKillTracker(Dictionary<string, int> TeamDamageByPlayer)
+        {
+            if(_instance != null)
+            {
+                _instance.TeamDamageByPlayer = TeamDamageByPlayer;
             }
         }
     }

--- a/Alliance.Client/Extensions/AdminMenu/ViewModels/AdminVM.cs
+++ b/Alliance.Client/Extensions/AdminMenu/ViewModels/AdminVM.cs
@@ -1,5 +1,6 @@
 ﻿using Alliance.Common.Core.Security.Extension;
 using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromClient;
+using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.Core.ViewModelCollection;
 using TaleWorlds.Library;
@@ -18,6 +19,7 @@ namespace Alliance.Client.Extensions.AdminMenu.ViewModels
         private string _Score;
         private string _KickCounter;
         private string _BanCounter;
+        private string _teamDamage;
         private string _WarningCounter;
         private string _filterText;
         private CharacterViewModel _unitCharacter;
@@ -26,6 +28,7 @@ namespace Alliance.Client.Extensions.AdminMenu.ViewModels
         private RolesVM _roles;
         private NetworkPeerVM _selectedPeer;
         private bool _isSudo;
+        private Dictionary<string, int> _teamDamageByPlayer;
 
         public AdminVM()
         {
@@ -258,6 +261,39 @@ namespace Alliance.Client.Extensions.AdminMenu.ViewModels
             }
         }
 
+        public Dictionary<string, int> TeamDamageByPlayer
+        {
+            get
+            {
+                return _teamDamageByPlayer;
+            }
+            set
+            {
+                if (value != _teamDamageByPlayer)
+                {
+                    _teamDamageByPlayer = value;
+                }
+            }
+        }
+
+        [DataSourceProperty]
+        public string TeamDamage
+        {
+            get
+            {
+                return _teamDamage;
+            }
+            set
+            {
+                if (value != _teamDamage)
+                {
+                    _teamDamage = value;
+                    FilterPlayers(_teamDamage);
+                    OnPropertyChangedWithValue(value, "TeamDamage");
+                }
+            }
+        }
+
         /// <summary>
         /// Filter list of players with given text filter
         /// </summary>
@@ -443,6 +479,7 @@ namespace Alliance.Client.Extensions.AdminMenu.ViewModels
             {
                 Health = selectedAgent.Health.ToString();
                 Position = selectedAgent.Position.ToString();
+                TeamDamage = (TeamDamageByPlayer  != null && TeamDamageByPlayer.ContainsKey(selectedAgent.Name)) ? TeamDamageByPlayer[selectedAgent.Name].ToString() : "0"; // If the team damage dictionary exist and has an entry for our player, we display the corresponding team damage value, otherwise  0
                 if (selectedAgent.Character != null) UnitCharacter.FillFrom(selectedAgent.Character);
             }
         }

--- a/Alliance.Client/_Module/GUI/Prefabs/Admin/AdminPanel.xml
+++ b/Alliance.Client/_Module/GUI/Prefabs/Admin/AdminPanel.xml
@@ -55,7 +55,10 @@
 									<Children>
 										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Left"  MarginRight="20" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="Kick : 0" />
 										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginRight="20" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="Ban : 0" />
-										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Right" MarginRight="20" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="Warning : 0" />
+										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Left" MarginRight="5" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="Warning : 0" />
+										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Right" MarginRight="20" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="Team Damage : " />
+										<RichTextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Left" MarginRight="5" VerticalAlignment="Center" Brush.FontSize="24" IsDisabled="true" Text="@TeamDamage" />
+
 									</Children>
 								</ListPanel>
 

--- a/Alliance.Common/Extensions/AdminMenu/NetworkMessages/FromServer/TeamKillTrackerLog.cs
+++ b/Alliance.Common/Extensions/AdminMenu/NetworkMessages/FromServer/TeamKillTrackerLog.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+using static Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer.AdminServerLog;
+using TaleWorlds.Diamond;
+using System;
+using System.Text;
+using System.Linq;
+using static Alliance.Common.Utilities.Logger;
+
+
+namespace Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer
+{
+    /// <summary>
+    /// TeamKillTrackerLog : used to transmit friendly fire data registered server side to the client
+    /// </summary>
+    [DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+    public sealed class TeamKillTrackerLog : GameNetworkMessage
+    {
+        // Only thing we transmit is the list of team damage done by player
+        public Dictionary<string, int> TeamDamageByPlayer { get; set; }
+
+        public TeamKillTrackerLog()
+        {
+        }
+
+        public TeamKillTrackerLog(Dictionary<string, int> teamDamageByPlayer)
+        {
+            TeamDamageByPlayer = teamDamageByPlayer;
+        }
+
+        protected override void OnWrite()
+        {
+            try
+            {
+                // Serializing the dictionary to a string before sending it
+                StringBuilder packetToSend = new StringBuilder();
+                foreach (KeyValuePair<string, int> playerTeamDamage in TeamDamageByPlayer)
+                {
+                    packetToSend.Append(playerTeamDamage.Key.Replace('~', ' ').Replace('|', ' ')); // We remove separator char from player names to avoid any deseriazlization problems
+                    packetToSend.Append('~');
+                    packetToSend.Append(playerTeamDamage.Value);
+                    packetToSend.Append('|');
+                }
+
+                // Sending to client the serialized string
+                WriteStringToPacket(packetToSend.ToString());
+            }
+            catch (Exception e)
+            {
+                Log($"Exception dans l'écriture de TeamKillTrackerLog : {e.Message}", LogLevel.Warning);
+            }
+        }
+
+        protected override bool OnRead()
+        {
+            
+            bool bufferReadValid = true;
+            try
+            {
+                TeamDamageByPlayer = new Dictionary<string, int>();
+                string packet = ReadStringFromPacket(ref bufferReadValid);
+
+                // Deserializing the string toa dictionary on reception
+                List<string> playerDamageList = packet.Split('|').ToList();
+                foreach (string playerDamage in playerDamageList)
+                {
+                    if (!string.IsNullOrWhiteSpace(playerDamage))
+                    {
+                        TeamDamageByPlayer.Add(playerDamage.Split('~')[0], int.Parse(playerDamage.Split('~')[1]));
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log($"Exception dans la lecture de TeamKillTrackerLog : {e.Message}", LogLevel.Warning);
+            }
+
+            return bufferReadValid;
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter()
+        {
+            return MultiplayerMessageFilter.Agents;
+        }
+        protected override string OnGetLogFormat()
+        {
+            return "Serveur Network message log";
+        }
+    }
+}

--- a/Alliance.Server/Extensions/TeamKillTracker/Behavior/TeamKillTrackerBehavior.cs
+++ b/Alliance.Server/Extensions/TeamKillTracker/Behavior/TeamKillTrackerBehavior.cs
@@ -1,0 +1,89 @@
+﻿using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
+using Alliance.Common.Extensions.TroopSpawner.Models;
+using Alliance.Server.Extensions.AIBehavior.TacticComponents;
+using Alliance.Server.Extensions.AIBehavior.TeamAIComponents;
+using Alliance.Server.Extensions.AIBehavior.Utils;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using TaleWorlds.Core;
+using TaleWorlds.Diamond;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.Network;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Server.Extensions.TeamKillTracker.Behavior
+{
+    /// <summary>
+    /// Centralized behavior for registering team damage
+    /// to prevent conflicts.
+    /// </summary>
+    public class TeamKillTrackerBehavior : MissionNetwork
+    {
+
+        public override MissionBehaviorType BehaviorType => MissionBehaviorType.Logic;
+
+        // Dictionary with the name of the player doing the damage as key and the amount of team damage registered so far as value
+        private Dictionary<string, int> _teamDamageByPlayer = new Dictionary<string, int>();
+
+        public override void OnBehaviorInitialize()
+        {
+            _teamDamageByPlayer = new Dictionary<string, int>();
+        }
+
+        public override void AfterStart()
+        {
+        }
+
+        public override void OnRemoveBehavior()
+        {
+        }
+
+        /// <summary>
+        /// OnAgentHit check if target is on the same team, if it is, register the damage in the _teamDamageByPlayer dictionay, send the dictionnary and an admin message to the client
+        /// </summary>
+        /// <param name="affectedAgent"></param>
+        /// <param name="affectorAgent"></param>
+        /// <param name="affectorWeapon"></param>
+        /// <param name="blow"></param>
+        /// <param name="attackCollisionData"></param>
+        public override void OnAgentHit(Agent affectedAgent, Agent affectorAgent, in MissionWeapon affectorWeapon, in Blow blow, in AttackCollisionData attackCollisionData)
+        {
+            try
+            {
+
+                // If the damage done is friendly
+                // Team might be null for Agent without team (ie : horses), in this case the damage done is ignored
+                if (affectorAgent.Team != null
+                    && affectedAgent.Team != null
+                    && affectorAgent.IsPlayerControlled == true
+                    && affectorAgent.Team.IsFriendOf(affectedAgent.Team))
+                {
+
+                    // Check the dictionary for friendly damage already done, if the player name is already known, we add the inflicted damage to the already logged damage in the dictionary, otherwise we add an entry for the player
+                    if (_teamDamageByPlayer.ContainsKey(affectorAgent.Name))
+                        _teamDamageByPlayer[affectorAgent.Name] += blow.InflictedDamage;
+                    else
+                        _teamDamageByPlayer.Add(affectorAgent.Name, blow.InflictedDamage);
+
+                    // Sending the dictionay with all the FF to the client via the TeamKillTrackerLog
+                    GameNetwork.BeginBroadcastModuleEvent();
+                    GameNetwork.WriteMessage(new TeamKillTrackerLog(_teamDamageByPlayer));
+                    GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients, null);        
+                    // Sending a message in the admin console notifying the FF
+                    GameNetwork.BeginBroadcastModuleEvent(); // Note : one broadcastmoduleevent seems to only be able to write 1 message, that's why it's duplicated here
+                    GameNetwork.WriteMessage(new AdminServerLog($"{affectorAgent.Name} touche son allie {affectedAgent.Name} pour {blow.InflictedDamage} ({_teamDamageByPlayer[affectorAgent.Name]})", AdminServerLog.ColorList.Warning));
+                    GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients, null);
+                }
+            }
+            catch (Exception e)
+            {
+                Log($"Exception dans le TeamKillTrackerBehavior : {e.Message}", LogLevel.Warning);
+            }
+
+        }
+
+
+    }
+}

--- a/Alliance.Server/GameModes/CvC/CvCGameMode.cs
+++ b/Alliance.Server/GameModes/CvC/CvCGameMode.cs
@@ -4,6 +4,7 @@ using Alliance.Common.Extensions.VOIP.Behaviors;
 using Alliance.Common.GameModes.CvC.Behaviors;
 using Alliance.Server.Extensions.SAE.Behaviors;
 using Alliance.Server.Extensions.SimpleRespawn.Behaviors;
+using Alliance.Server.Extensions.TeamKillTracker.Behavior;
 using Alliance.Server.GameModes.PvC.Behaviors;
 using Alliance.Server.Patch.Behaviors;
 using System.Collections.Generic;
@@ -51,7 +52,8 @@ namespace Alliance.Server.GameModes.CvC
                     new MissionOptionsComponent(),
                     new MissionScoreboardComponent(new CaptainScoreboardData()),
                     new EquipmentControllerLeaveLogic(),
-                    new MultiplayerPreloadHelper()
+                    new MultiplayerPreloadHelper(),
+                    new TeamKillTrackerBehavior()
             };
 
             if (Config.Instance.ActivateSAE)

--- a/Alliance.Server/GameModes/PvC/PvCGameMode.cs
+++ b/Alliance.Server/GameModes/PvC/PvCGameMode.cs
@@ -4,6 +4,7 @@ using Alliance.Common.Extensions.VOIP.Behaviors;
 using Alliance.Common.GameModes.PvC.Behaviors;
 using Alliance.Server.Extensions.SAE.Behaviors;
 using Alliance.Server.Extensions.SimpleRespawn.Behaviors;
+using Alliance.Server.Extensions.TeamKillTracker.Behavior;
 using Alliance.Server.GameModes.PvC.Behaviors;
 using Alliance.Server.Patch.Behaviors;
 using System.Collections.Generic;
@@ -51,7 +52,8 @@ namespace Alliance.Server.GameModes.PvC
                     new MissionOptionsComponent(),
                     new MissionScoreboardComponent(new CaptainScoreboardData()),
                     new EquipmentControllerLeaveLogic(),
-                    new MultiplayerPreloadHelper()
+                    new MultiplayerPreloadHelper(),
+                    new TeamKillTrackerBehavior()
             };
 
             if (Config.Instance.ActivateSAE)


### PR DESCRIPTION
Pour l'instant tout est synchronisé à chaque hit FF.

Pour des raisons de perfs en V2 il serait ptet intéressant de découpler l'envoi au client du dico de FF et l'enregistrement en local sur le serveur.

L'envoi est un peu pourri aussi je pense qu'on peut faire mieux ,j'ai des doutes sur la capacité de la chose à gérer de gros volumes de données.

Tout est à peu près safe normalement avec tout ce qui est à risque dans des try catch.

J'ai mis le behaviour que sur le CvC et le PvC pour le moment.



Test implementation OpenProject:
OP#40