### PR TITLE
Add reset system on usable entities

### DIFF
--- a/Alliance.Client/Extensions/UsableEntity/Handlers/UsableEntityHandler.cs
+++ b/Alliance.Client/Extensions/UsableEntity/Handlers/UsableEntityHandler.cs
@@ -2,6 +2,7 @@
 using Alliance.Common.Extensions.UsableEntity.Behaviors;
 using Alliance.Common.Extensions.UsableEntity.NetworkMessages.FromServer;
 using System;
+using TaleWorlds.Engine;
 using TaleWorlds.MountAndBlade;
 using static Alliance.Common.Utilities.Logger;
 using static TaleWorlds.MountAndBlade.GameNetwork;
@@ -23,17 +24,32 @@ namespace Alliance.Client.Extensions.UsableEntity.Handlers
         public void Register(NetworkMessageHandlerRegisterer reg)
         {
             reg.Register<RemoveEntity>(RemoveEntity);
+            reg.Register<Reset>(Reset);
         }
 
         public void RemoveEntity(RemoveEntity message)
         {
             try
             {
-                GameMode.RemoveEntity(GameMode.FindClosestUsableEntity(message.Position, 0.1f));
+                GameEntity closestEntityToRemove = GameMode.FindClosestUsableEntity(message.Position, 0.05f);
+                GameMode.HideEntity(closestEntityToRemove);
             }
             catch (Exception ex)
             {
                 Log($"Alliance - Failed to remove entity at {message.Position}", LogLevel.Error);
+                Log(ex.ToString(), LogLevel.Error);
+            }
+        }
+
+        public void Reset(Reset message)
+        {
+            try
+            {
+                GameMode.ResetItemsWithTagRespawnEachRound();
+            }
+            catch (Exception ex)
+            {
+                Log("Alliance - Failed to reset usable items ", LogLevel.Error);
                 Log(ex.ToString(), LogLevel.Error);
             }
         }

--- a/Alliance.Common/Extensions/UsableEntity/Behaviors/UsableEntityBehavior.cs
+++ b/Alliance.Common/Extensions/UsableEntity/Behaviors/UsableEntityBehavior.cs
@@ -18,10 +18,18 @@ namespace Alliance.Common.Extensions.UsableEntity.Behaviors
     {
         private List<GameEntity> _usableEntities = new List<GameEntity>();
 
+        readonly MultiplayerRoundController roundController;
+
         public override void OnBehaviorInitialize()
         {
             base.OnBehaviorInitialize();
             _usableEntities = Mission.Current.Scene.FindEntitiesWithTag(AllianceTags.InteractiveTag).ToList();
+            MultiplayerRoundController roundController = Mission.GetMissionBehavior<MultiplayerRoundController>();
+
+            if (roundController != null)
+            {
+                roundController.OnRoundStarted += ResetItemsWithTagRespawnEachRound;
+            }
         }
 
         public void UseEntity(GameEntity entity, Agent agent)
@@ -37,12 +45,21 @@ namespace Alliance.Common.Extensions.UsableEntity.Behaviors
             agent.EquipWeaponWithNewEntity(slot, ref missionWeapon);
             agent.TryToWieldWeaponInSlot(slot, Agent.WeaponWieldActionType.WithAnimation, true);
 
-            RemoveEntity(entity);
+            HideEntity(entity);
 
             Log($"Agent {agent.Name} ({agent.MissionPeer?.Name}) used entity {entity.Name} and equipped {itemName}", LogLevel.Debug);
         }
 
-        public void RemoveEntity(GameEntity entity)
+        public override void OnRemoveBehavior()
+        {
+            if (roundController != null)
+            {
+                roundController.OnRoundStarted -= ResetItemsWithTagRespawnEachRound;
+            }
+            base.OnRemoveBehavior();
+        }
+
+        public void HideEntity(GameEntity entity)
         {
             if (entity == null) return;
 
@@ -53,8 +70,28 @@ namespace Alliance.Common.Extensions.UsableEntity.Behaviors
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
 
-            entity.Remove(0);
-            _usableEntities.Remove(entity);
+            entity.SetVisibilityExcludeParents(false);
+        }
+
+        public void ResetItemsWithTagRespawnEachRound()
+        {
+            List<GameEntity> itemsToRespawnList = Mission.Current.Scene.FindEntitiesWithTag(AllianceTags.ENTITY_TO_RESPAWN_ON_EACH_ROUND_TAG).ToList();
+
+            if (GameNetwork.IsServer)
+            {
+                // As client to make them visible again (Code above in the foreach)
+                GameNetwork.BeginBroadcastModuleEvent();
+                GameNetwork.WriteMessage(new Reset());
+                GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+            }
+
+            itemsToRespawnList.ForEach(gameEntity =>
+            {
+                if (!gameEntity.IsVisibleIncludeParents())
+                {
+                    gameEntity.SetVisibilityExcludeParents(true);
+                }
+            });
         }
 
         public GameEntity FindClosestUsableEntity(Vec3 position, float range)
@@ -80,7 +117,7 @@ namespace Alliance.Common.Extensions.UsableEntity.Behaviors
             foreach (GameEntity entity in _usableEntities)
             {
                 // Check if the entity is in the direction the agent is looking
-                if (IsEntityInLookDirection(entity, eyePosition, lookDirection, out float distanceSquared))
+                if (IsEntityInLookDirection(entity, eyePosition, lookDirection, out float distanceSquared) && entity.IsVisibleIncludeParents())
                 {
                     if (distanceSquared < closestDistanceSquared)
                     {
@@ -89,7 +126,6 @@ namespace Alliance.Common.Extensions.UsableEntity.Behaviors
                     }
                 }
             }
-
             return closestEntity;
         }
 

--- a/Alliance.Common/Extensions/UsableEntity/NetworkMessages/FromServer/Reset.cs
+++ b/Alliance.Common/Extensions/UsableEntity/NetworkMessages/FromServer/Reset.cs
@@ -1,0 +1,31 @@
+﻿using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.UsableEntity.NetworkMessages.FromServer
+{
+    [DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+    public sealed class Reset : GameNetworkMessage
+    {
+        // This empty constructor is required so the engine recognize this class as a valid NetworkMessage
+        public Reset() { }
+
+        protected override void OnWrite()
+        {
+        }
+
+        protected override bool OnRead()
+        {
+            bool bufferReadValid = true;
+            return bufferReadValid;
+        }
+
+        protected override MultiplayerMessageFilter OnGetLogFilter()
+        {
+            return MultiplayerMessageFilter.MissionObjects;
+        }
+        protected override string OnGetLogFormat()
+        {
+            return $"Ask client to make object visible again";
+        }
+    }
+}

--- a/Alliance.Common/Extensions/UsableEntity/Utilities/AllianceTags.cs
+++ b/Alliance.Common/Extensions/UsableEntity/Utilities/AllianceTags.cs
@@ -19,6 +19,8 @@ namespace Alliance.Common.Extensions.UsableEntity.Utilities
         public const string InteractiveTeamTag = "al_team_"; // Not implemented yet
         public const string InteractiveAmountTag = "al_amount_"; // Not implemented yet
 
+        public const string ENTITY_TO_RESPAWN_ON_EACH_ROUND_TAG = "al_respawn_on_each_round";
+
         /// <summary>
         /// Return the tag value that maches the prefix. Returns empty if no match found.
         /// </summary>

--- a/Alliance.Server/Extensions/SAE/Behaviors/SaeBehavior.cs
+++ b/Alliance.Server/Extensions/SAE/Behaviors/SaeBehavior.cs
@@ -50,9 +50,9 @@ namespace Alliance.Server.Extensions.SAE.Behaviors
 
             //Init dynamicMarkersDico
             List<GameEntity> gameEntities = new();
-            Mission.Current.Scene.GetEntities(ref gameEntities);
             saeDynamicMapMarkersDico = new Dictionary<MatrixFrame, bool>();
-            gameEntities.Where(entity => entity.HasTag(SaeCommonConstants.FDC_QUICK_PLACEMENT_POS_TAG_NAME)).ToList()
+
+            Mission.Current.Scene.FindEntitiesWithTag(SaeCommonConstants.FDC_QUICK_PLACEMENT_POS_TAG_NAME).ToList()
                 .ForEach(entity =>
                     saeDynamicMapMarkersDico.Add(
                         entity.GetGlobalFrame(),

--- a/Alliance.Server/Extensions/UsableEntity/Handlers/UsableEntityHandler.cs
+++ b/Alliance.Server/Extensions/UsableEntity/Handlers/UsableEntityHandler.cs
@@ -30,7 +30,7 @@ namespace Alliance.Server.Extensions.UsableEntity.Handlers
         /// </summary>
         public bool HandleRequestUseEntity(NetworkCommunicator peer, RequestUseEntity model)
         {
-            GameEntity entity = GameMode.FindClosestUsableEntity(model.Position, 0.01f);
+            GameEntity entity = GameMode.FindClosestUsableEntity(model.Position, 0.05f);
             if (entity == null || peer.ControlledAgent == null)
             {
                 string reason = entity == null ? "Entity not found" : "No agent controlled";


### PR DESCRIPTION
Update usable entity in order to no more delete object but to make them invisible.
Also, when tag `al_respawn_on_each_round` is set, the object visibility will be reset each round.