### PR TITLE
Formation buff for different type

### DIFF
--- a/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
+++ b/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
@@ -139,6 +139,15 @@ namespace Alliance.Common.Core.Configuration.Models
 		[ConfigProperty("Minimum alive troops for formation", "Minimum number of troops alive for the formation system to be enabled.", ConfigValueType.Integer, 0, 200)]
 		public int MinPlayerForm = 15;
 
+		[ConfigProperty("Cavalry formation radius multiplier", "Radius of cavalry formation will be increase by this multiplicator (Base on infantry radius).", ConfigValueType.Float, 0.1f, 5)]
+		public float CavFormationRadiusMultiplier = 2f;
+		[ConfigProperty("Archer formation radius multiplier", "Radius of archer formation will be increase by this multiplicator (Base on infantry radius).", ConfigValueType.Float, 0.1f, 5)]
+		public float RangedFormationRadiusMultiplier = 1.7f;
+		[ConfigProperty("Cavalry skirmish radius multiplier", "Radius of cavalry skirmish will be increase by this multiplicator (Base on infantry radius).", ConfigValueType.Float, 0.1f, 5)]
+		public float CavSkirmishRadiusMultiplier = 1.5f;
+		[ConfigProperty("Archer skirmish radius multiplier", "Radius of archer skirmish will be increase by this multiplicator (Base on infantry radius).", ConfigValueType.Float, 0.1f, 5)]
+		public float RangedSkirmishRadiusMultiplier = 1.2f;
+
 		[ConfigProperty("Melee debuff for rambo", "Melee debuff for people in rambo state. Range from 0 (hardest) to 1 (no effect).", ConfigValueType.Float, 0f, 1f)]
 		public float MeleeDebuffRambo = 0.6f;
 		[ConfigProperty("Distance debuff for rambo", "Distance debuff for people in rambo state. Range from 0 (hardest) to 1 (no effect).", ConfigValueType.Float, 0f, 1f)]

--- a/Alliance.Common/GameModels/FormationCalculateModel.cs
+++ b/Alliance.Common/GameModels/FormationCalculateModel.cs
@@ -49,7 +49,7 @@ namespace Alliance.Common.GameModels
 
 		private static bool IsCavalryInFormation(Agent player, bool ownFormationOnly = true)
 		{
-			return IsInFormation(player, ownFormationOnly, 2f);
+			return IsInFormation(player, ownFormationOnly, Config.Instance.CavFormationRadiusMultiplier);
 		}
 
 		private static bool IsInfantryInFormation(Agent player, bool ownFormationOnly = true)
@@ -59,13 +59,13 @@ namespace Alliance.Common.GameModels
 
 		private static bool IsRangedInFormation(Agent player, bool ownFormationOnly = true)
 		{
-			return IsInFormation(player, ownFormationOnly, 1.7f);
+			return IsInFormation(player, ownFormationOnly, Config.Instance.RangedFormationRadiusMultiplier);
 		}
 
 
 		private static bool IsCavalryInSkirmish(Agent player, bool ownFormationOnly = true)
 		{
-			return IsInSkirmish(player, ownFormationOnly, 1.5f);
+			return IsInSkirmish(player, ownFormationOnly, Config.Instance.CavSkirmishRadiusMultiplier);
 		}
 
 		private static bool IsInfantryInSkirmish(Agent player, bool ownFormationOnly = true)
@@ -75,7 +75,7 @@ namespace Alliance.Common.GameModels
 
 		private static bool IsRangedInSkirmish(Agent player, bool ownFormationOnly = true)
 		{
-			return IsInSkirmish(player, ownFormationOnly, 1.2f);
+			return IsInSkirmish(player, ownFormationOnly, Config.Instance.RangedSkirmishRadiusMultiplier);
 		}
 
 		private static bool IsInFormation(Agent player, bool ownFormationOnly, float radiusMultiplier)

--- a/Alliance.Common/GameModels/FormationCalculateModel.cs
+++ b/Alliance.Common/GameModels/FormationCalculateModel.cs
@@ -5,60 +5,113 @@ using TaleWorlds.MountAndBlade;
 
 namespace Alliance.Common.GameModels
 {
-    public static class FormationCalculateModel
-    {
-        public static bool IsInFormation(Agent player, bool ownFormationOnly = true)
-        {
-            // Multiplier = (ActiveAgents - MinPlayerValue) / (MinPlayerValue + MaxPlayerValue)
-            // Radius = RadiusMin + ( Multiplier * (RadiusMax - RadiusMin) )
-            // RequiredAllies = NbAlliesForFormationMin + ( Multiplier * (NbAlliesForFormationMax - NbAlliesForFormationMin) )
-            float multiplier = (player.Team.ActiveAgents.Count - Config.Instance.MinPlayer) / (Config.Instance.MinPlayer + Config.Instance.MaxPlayer);
-            float radius = Config.Instance.FormRadMin + multiplier * (Config.Instance.FormRadMax - Config.Instance.FormRadMin);
-            int requiredAllies = (int)(Config.Instance.NbFormMin + multiplier * (Config.Instance.NbFormMax - Config.Instance.NbFormMin));
+	public static class FormationCalculateModel
+	{
+		public static bool IsInFormation(Agent player, bool ownFormationOnly = true)
+		{
+			if (player == null || player.Formation == null)
+			{
+				return false;
+			}
 
-            MBList<Agent> target = new() { player };
-            MBList<Agent> nearbyAllies = Mission.Current.GetNearbyAllyAgents(player.Position.AsVec2, radius, player.Team, target);
-            int nbNearbyAllies = nearbyAllies.Count() - 1;
-            if (ownFormationOnly)
-            {
-                nbNearbyAllies = nearbyAllies.Where(agent => agent.Formation == player.Formation).Count() - 1;
-            }
+			switch (player.Formation.FormationIndex)
+			{
+				case TaleWorlds.Core.FormationClass.Cavalry:
+					return IsCavalryInFormation(player, false);
+				case TaleWorlds.Core.FormationClass.Ranged:
+					return IsRangedInFormation(player, false);
+				case TaleWorlds.Core.FormationClass.Infantry:
+					return IsInfantryInFormation(player, false);
+				default:
+					return IsInfantryInFormation(player, false);
+			}
+		}
 
-            if (nbNearbyAllies >= requiredAllies)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+		public static bool IsInSkirmish(Agent player, bool ownFormationOnly = true)
+		{
+			if (player == null || player.Formation == null)
+			{
+				return false;
+			}
 
-        public static bool IsInSkirmish(Agent player, bool ownFormationOnly = true)
-        {
-            // Multiplier = (ActiveAgents - MinPlayerValue) / (MinPlayerValue + MaxPlayerValue)
-            // Radius = RadiusMin + ( Multiplier * (RadiusMax - RadiusMin) )
-            // RequiredAllies = NbAlliesForSkirmishMin + ( Multiplier * (NbAlliesForSkirmishMax - NbAlliesForSkirmishMin) )
-            float multiplier = (player.Team.ActiveAgents.Count - Config.Instance.MinPlayer) / (Config.Instance.MinPlayer + Config.Instance.MaxPlayer);
-            float radius = Config.Instance.SkirmRadMin + multiplier * (Config.Instance.SkirmRadMax - Config.Instance.SkirmRadMin);
-            int requiredAllies = (int)(Config.Instance.NbSkirmMin + multiplier * (Config.Instance.NbSkirmMax - Config.Instance.NbSkirmMin));
+			switch (player.Formation.FormationIndex)
+			{
+				case TaleWorlds.Core.FormationClass.Cavalry:
+					return IsCavalryInSkirmish(player, false);
+				case TaleWorlds.Core.FormationClass.Ranged:
+					return IsRangedInSkirmish(player, false);
+				case TaleWorlds.Core.FormationClass.Infantry:
+					return IsInfantryInSkirmish(player, false);
+				default:
+					return IsInfantryInSkirmish(player, false);
+			}
+		}
 
-            MBList<Agent> target = new() { player };
-            MBList<Agent> nearbyAllies = Mission.Current.GetNearbyAllyAgents(player.Position.AsVec2, radius, player.Team, target);
-            int nbNearbyAllies = nearbyAllies.Count() - 1;
-            if (ownFormationOnly)
-            {
-                nbNearbyAllies = nearbyAllies.Where(agent => agent.Formation == player.Formation).Count() - 1;
-            }
+		private static bool IsCavalryInFormation(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInFormation(player, ownFormationOnly, 2f);
+		}
 
-            if (nbNearbyAllies >= requiredAllies)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-    }
+		private static bool IsInfantryInFormation(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInFormation(player, ownFormationOnly, 1.0f);
+		}
+
+		private static bool IsRangedInFormation(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInFormation(player, ownFormationOnly, 1.7f);
+		}
+
+
+		private static bool IsCavalryInSkirmish(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInSkirmish(player, ownFormationOnly, 1.5f);
+		}
+
+		private static bool IsInfantryInSkirmish(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInSkirmish(player, ownFormationOnly, 1.0f);
+		}
+
+		private static bool IsRangedInSkirmish(Agent player, bool ownFormationOnly = true)
+		{
+			return IsInSkirmish(player, ownFormationOnly, 1.2f);
+		}
+
+		private static bool IsInFormation(Agent player, bool ownFormationOnly, float radiusMultiplier)
+		{
+			float multiplier = ((float)player.Team.ActiveAgents.Count - Config.Instance.MinPlayer) / (Config.Instance.MinPlayer + Config.Instance.MaxPlayer);
+			float radius = (Config.Instance.FormRadMin + multiplier * (Config.Instance.FormRadMax - Config.Instance.FormRadMin)) * radiusMultiplier;
+			// More there are alive players, more the requiredAllies value will tends to NbFormMax
+			int requiredAllies = (int)(Config.Instance.NbFormMin + (multiplier * (Config.Instance.NbFormMax - Config.Instance.NbFormMin)));
+
+			MBList<Agent> target = new() { player };
+			MBList<Agent> nearbyAllies = Mission.Current.GetNearbyAllyAgents(player.Position.AsVec2, radius, player.Team, target);
+			int nbNearbyAllies = nearbyAllies.Count() - 1;
+			if (ownFormationOnly)
+			{
+				nbNearbyAllies = nearbyAllies.Where(agent => agent.Formation == player.Formation).Count() - 1;
+			}
+
+			return nbNearbyAllies >= requiredAllies;
+		}
+
+		private static bool IsInSkirmish(Agent player, bool ownFormationOnly, float radiusMultiplier)
+		{
+			float multiplier = ((float)player.Team.ActiveAgents.Count - Config.Instance.MinPlayer) / (Config.Instance.MinPlayer + Config.Instance.MaxPlayer);
+			float radius = (Config.Instance.SkirmRadMin + multiplier * (Config.Instance.SkirmRadMax - Config.Instance.SkirmRadMin)) * radiusMultiplier;
+			// More there are alive players, more the requiredAllies value will tends to NbSkirmMax
+			int requiredAllies = (int)(Config.Instance.NbSkirmMin + multiplier * (Config.Instance.NbSkirmMax - Config.Instance.NbSkirmMin));
+
+			MBList<Agent> target = new() { player };
+			MBList<Agent> nearbyAllies = Mission.Current.GetNearbyAllyAgents(player.Position.AsVec2, radius, player.Team, target);
+			int nbNearbyAllies = nearbyAllies.Count() - 1;
+			if (ownFormationOnly)
+			{
+				nbNearbyAllies = nearbyAllies.Where(agent => agent.Formation == player.Formation).Count() - 1;
+			}
+
+			return nbNearbyAllies >= requiredAllies;
+		}
+	}
 }


### PR DESCRIPTION
[OP#262](http://51.178.133.139:8080/projects/alliance-v0-dot-4/work_packages/262/activity)
- Update formation buff by adding buff depending on player formation (archer / inf / cav)
- Fix a bug where `multiplier` was not a correct float