### PR TITLE
[OP#240] Small fixes for event

### DIFF
--- a/Alliance.Client/Extensions/ExNativeUI/EscapeMenu/Views/EscapeMenuView.cs
+++ b/Alliance.Client/Extensions/ExNativeUI/EscapeMenu/Views/EscapeMenuView.cs
@@ -119,25 +119,26 @@ namespace Alliance.Client.Extensions.ExNativeUI.EscapeMenu.Views
 			}
 
 			// Change Team
-			if (gameType != "Scenario" || GameNetwork.MyPeer.IsAdmin())
+			// TODO : Limit team changes once we've properly implemented the team selection UI ?
+			//if (gameType != "Scenario" || GameNetwork.MyPeer.IsAdmin())
+			//{
+			if (_missionTeamSelectComponent != null && _missionTeamSelectComponent.TeamSelectionEnabled)
 			{
-				if (_missionTeamSelectComponent != null && _missionTeamSelectComponent.TeamSelectionEnabled)
+				list.Add(new EscapeMenuItemVM(new TextObject("{=2SEofGth}Change Team", null), delegate (object o)
 				{
-					list.Add(new EscapeMenuItemVM(new TextObject("{=2SEofGth}Change Team", null), delegate (object o)
-					{
-						OnEscapeMenuToggled(false);
-						_missionTeamSelectComponent.SelectTeam();
-					}, null, () => new Tuple<bool, TextObject>(false, TextObject.Empty), false));
-				}
-				else if (_missionTeamSelectComponent != null && _missionTeamSelectComponent.TeamSelectionEnabled)
-				{
-					list.Add(new EscapeMenuItemVM(new TextObject("{=2SEofGth}Change Team", null), delegate (object o)
-					{
-						OnEscapeMenuToggled(false);
-						_missionTeamSelectComponent.SelectTeam();
-					}, null, () => new Tuple<bool, TextObject>(false, TextObject.Empty), false));
-				}
+					OnEscapeMenuToggled(false);
+					_missionTeamSelectComponent.SelectTeam();
+				}, null, () => new Tuple<bool, TextObject>(false, TextObject.Empty), false));
 			}
+			else if (_missionTeamSelectComponent != null && _missionTeamSelectComponent.TeamSelectionEnabled)
+			{
+				list.Add(new EscapeMenuItemVM(new TextObject("{=2SEofGth}Change Team", null), delegate (object o)
+				{
+					OnEscapeMenuToggled(false);
+					_missionTeamSelectComponent.SelectTeam();
+				}, null, () => new Tuple<bool, TextObject>(false, TextObject.Empty), false));
+			}
+			//}
 
 			// Options
 			list.Add(new EscapeMenuItemVM(new TextObject("{=NqarFr4P}Options", null), delegate (object o)

--- a/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
+using TaleWorlds.LinQuick;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.ObjectSystem;
 using static Alliance.Common.GameModes.Story.Conditions.Condition;
@@ -39,13 +40,47 @@ namespace Alliance.Server.GameModes.Story.Actions
 			MissionPeer playerInCharge = FormationControlModel.Instance.GetControllerOfFormation(Formation, team);
 			if (playerInCharge?.ControlledAgent == null)
 			{
-				// If no player is controlling this formation, try to assign the closest player in the team
-				List<NetworkCommunicator> candidates = GameNetwork.NetworkPeers.Where(peer => peer.ControlledAgent != null && peer.ControlledAgent.Team == team).ToList();
-				if (candidates.Count > 0)
+				int totalFormations = (int)FormationClass.NumberOfDefaultFormations;
+
+				// Get list of players in the same team
+				List<NetworkCommunicator> candidates = GameNetwork.NetworkPeers.Where(peer => peer.GetComponent<MissionPeer>()?.Team == team).ToList();
+				// Sort them by their index for consistent distribution
+				candidates.OrderByQ(peer => peer.Index);
+				// Limit the number of candidates to the number of formations
+				int candidatesCount = Math.Min(candidates.Count, totalFormations);
+
+				// Distribute the formation depending on number of players in the team
+				if (candidatesCount > 1)
 				{
-					Agent closestAgent = candidates.OrderBy(peer => peer.ControlledAgent.Position.DistanceSquared(SpawnZone.GlobalPosition)).First().ControlledAgent;
-					playerInCharge = closestAgent.MissionPeer;
+					int baseFormationCountPerPlayer = totalFormations / candidatesCount;
+					int remainingFormations = totalFormations % candidatesCount;
+
+					int nbFormationAlreadyAssigned = 0;
+					for (int i = 0; i < candidatesCount; i++)
+					{
+						// If there are remaining formations, assign one more to the first players
+						int nbFormationForThisPlayer = baseFormationCountPerPlayer + (i < remainingFormations ? 1 : 0);
+
+						if ((int)Formation < nbFormationAlreadyAssigned + nbFormationForThisPlayer)
+						{
+							playerInCharge = candidates[i].GetComponent<MissionPeer>();
+							break;
+						}
+						nbFormationAlreadyAssigned += nbFormationForThisPlayer;
+					}
+				}
+				else if (candidatesCount == 1)
+				{
+					playerInCharge = candidates[0].GetComponent<MissionPeer>();
+				}
+
+				if (playerInCharge != null)
+				{
 					FormationControlModel.Instance.AssignControlToPlayer(playerInCharge, Formation, true);
+				}
+				else
+				{
+					Log("No player eligible to control formation " + Formation, LogLevel.Warning);
 				}
 			}
 


### PR DESCRIPTION
[OP#240](http://51.178.133.139:8080/projects/alliance-v0-dot-4/work_packages/240/activity)
Small fixes in preparation of event :
- Allow non-admin to change team in case they're stuck in the wrong one...
- Change formation assignment logic to distribute them more equally, example : 
  - 8 players = each player get a formation
  - 2 players = each player get 4 formations
  - 5 players = 3 players get 2 formations, 2 players get 1 formation
 (Distance between player and formation is not used anymore)