### PR TITLE
Suggestion of refactoring on Messages declaration

### DIFF
--- a/Alliance.Common/Extensions/AdminMenu/CommonAdminMsg.cs
+++ b/Alliance.Common/Extensions/AdminMenu/CommonAdminMsg.cs
@@ -1,0 +1,35 @@
+﻿
+using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Client.Extensions.AdminMenu
+{
+	public static class CommonAdminMsg
+	{
+		public static void SendNotificationToAll(string message, int notificationType)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(new SendNotification(message, notificationType));
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+
+		public static void SendNotificationToAll(string message)
+		{
+			SendNotificationToAll(message, 0);
+		}
+
+		public static void SendInformationToAll(string message)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(new SendNotification(message, 1));
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+
+		public static void SendNotificationToPeerAsServer(NetworkCommunicator target, string message)
+		{
+			GameNetwork.BeginModuleEventAsServer(target);
+			GameNetwork.WriteMessage(new SendNotification(message, 0));
+			GameNetwork.EndModuleEventAsServer();
+		}
+	}
+}

--- a/Alliance.Common/Utilities/Logger.cs
+++ b/Alliance.Common/Utilities/Logger.cs
@@ -1,5 +1,4 @@
-﻿using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
-using NetworkMessages.FromServer;
+﻿using NetworkMessages.FromServer;
 using System;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -90,20 +89,6 @@ namespace Alliance.Common.Utilities
 			GameNetwork.BeginModuleEventAsServer(peer);
 			GameNetwork.WriteMessage(new ServerMessage(message));
 			GameNetwork.EndModuleEventAsServer();
-		}
-
-		public static void SendInformationToAll(string message)
-		{
-			GameNetwork.BeginBroadcastModuleEvent();
-			GameNetwork.WriteMessage(new SendNotification(message, 1));
-			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
-		}
-
-		public static void SendNotificationToAll(string message)
-		{
-			GameNetwork.BeginBroadcastModuleEvent();
-			GameNetwork.WriteMessage(new SendNotification(message, 0));
-			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
 		}
 
 		public static void SendAdminNotificationToAll(string message, bool broadcast = true)

--- a/Alliance.Server/Extensions/AdminMenu/Handlers/AdminMenuHandler.cs
+++ b/Alliance.Server/Extensions/AdminMenu/Handlers/AdminMenuHandler.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Core.Security.Extension;
+﻿using Alliance.Client.Extensions.AdminMenu;
+using Alliance.Common.Core.Security.Extension;
 using Alliance.Common.Core.Utils;
 using Alliance.Common.Extensions;
 using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromClient;
@@ -70,7 +71,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 
 			peer.ControlledAgent.TeleportToPosition(req.Position);
 			Log($"[AdminPanel] L'admin {peer.UserName} s'est téléporté en {req.Position}", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] L'admin {peer.UserName} s'est téléporté en {req.Position}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] L'admin {peer.UserName} s'est téléporté en {req.Position}", AdminServerLog.ColorList.Success, true);
 
 			return true;
 		}
@@ -79,9 +80,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 		{
 			if (peer.IsAdmin())
 			{
-				GameNetwork.BeginBroadcastModuleEvent();
-				GameNetwork.WriteMessage(new SendNotification(notification.Text, notification.NotificationType));
-				GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+				CommonAdminMsg.SendNotificationToAll(notification.Text, notification.NotificationType);
 			}
 
 			return false;
@@ -140,7 +139,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			teleportPlayersToYou(new List<NetworkCommunicator> { playerSelected }, peer);
 
 			Log($"[AdminPanel] Le joueur {playerSelected.UserName} a été téléporté par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été téléporté par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été téléporté par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -151,7 +150,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			teleportPlayersToYou(playerSelected, peer);
 
 			Log($"[AdminPanel] Tous les joueurs ont été téléportés par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été téléportés par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été téléportés par l'administrateur {peer.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -165,7 +164,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			peer.ControlledAgent.TeleportToPosition(playerSelected.ControlledAgent.Position);
 
 			Log($"[AdminPanel] L'administrateur {peer.UserName} s'est téléporté sur le joueur {playerSelected.UserName} ({peer.ControlledAgent.Position})", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] L'administrateur {peer.UserName} s'est téléporté sur le joueur {playerSelected.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] L'administrateur {peer.UserName} s'est téléporté sur le joueur {playerSelected.UserName} ({peer.ControlledAgent.Position})", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -176,7 +175,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			healPlayers(new List<NetworkCommunicator> { playerSelected }, peer);
 
 			Log($"[AdminPanel] Le joueur : {playerSelected?.UserName} a été soigné par l'administrateur {peer.UserName}", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected?.UserName} est soigné par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected?.UserName} est soigné par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -189,14 +188,14 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			{
 				Mission.Current.GetMissionBehavior<RespawnBehavior>().RespawnPlayer(playerSelected);
 				Log($"[AdminPanel] Le joueur : {playerSelected?.UserName} a été respawn par l'administrateur {peer.UserName}", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected?.UserName} est respawn par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected?.UserName} est respawn par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				return true;
 
 			}
 			else
 			{
 				Log($"[AdminPanel] Erreur lors du respawn, le joueur n'est pas dans une équipe ", LogLevel.Information);
-				SendMessageToClient(peer, $"[AdminPanel]  Erreur lors du respawn, le joueur n'est pas dans une équipe.", AdminServerLog.ColorList.Danger, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[AdminPanel]  Erreur lors du respawn, le joueur n'est pas dans une équipe.", AdminServerLog.ColorList.Danger, true);
 				return false;
 			}
 
@@ -209,7 +208,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			healPlayers(playersSelected, peer);
 
 			Log($"[AdminPanel] Tous les joueurs ont été soignés par l'administrateur {peer.UserName}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été soignés par l'administrateur {peer.UserName}.", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été soignés par l'administrateur {peer.UserName}.", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -220,7 +219,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			godModPlayers(new List<NetworkCommunicator> { playerSelected }, peer);
 
 			Log($"[AdminPanel] Le joueur : {playerSelected.UserName} est en GodMod grâce à l'admin {peer.UserName}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été mis en GodMod par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été mis en GodMod par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 
 			return true;
 		}
@@ -232,7 +231,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			godModPlayers(playersSelected, peer);
 
 			Log($"[AdminPanel] Tous les joueurs entrent en GodMod grâce à l'admin {peer.UserName}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Tous les joueurs entrent en GodMod grâce à l'admin {peer.UserName}.", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Tous les joueurs entrent en GodMod grâce à l'admin {peer.UserName}.", AdminServerLog.ColorList.Success, true);
 
 			return true;
 		}
@@ -244,7 +243,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			killPlayers(playersToKill, peer);
 
 			Log($"[AdminPanel] Tous les joueurs ont été tués par l'admin {peer.UserName}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été tués par l'admin {peer.UserName}.", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Tous les joueurs ont été tués par l'admin {peer.UserName}.", AdminServerLog.ColorList.Success, true);
 			return true;
 		}
 
@@ -257,7 +256,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			killPlayers(new List<NetworkCommunicator> { playerSelected }, peer);
 
 			Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été tué par l'admin {peer.UserName}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été tué par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été tué par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 
 			return true;
 		}
@@ -270,13 +269,10 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			if (playerSelected == null) return false;
 			admin.WarningMessageToPlayer = string.IsNullOrEmpty(admin.WarningMessageToPlayer) ? "Vous avez reçu un avertissement d'un Admin" : admin.WarningMessageToPlayer;
 
-
-			GameNetwork.BeginModuleEventAsServer(playerSelected);
-			GameNetwork.WriteMessage(new SendNotification($"{admin.WarningMessageToPlayer} (Admin : {peer.UserName}) !", 0));
-			GameNetwork.EndModuleEventAsServer();
+			CommonAdminMsg.SendNotificationToPeerAsServer(playerSelected, $"{admin.WarningMessageToPlayer} (Admin : {peer.UserName}) !");
 
 			Log($"[AdminPanel] Le joueur {playerSelected.UserName} a reçu un avertissement par {peer.UserName} avec la raison suivante : {admin.WarningMessageToPlayer}.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a reçu un avertissement par {peer.UserName} avec la raison suivante : {admin.WarningMessageToPlayer}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a reçu un avertissement par {peer.UserName} avec la raison suivante : {admin.WarningMessageToPlayer}", AdminServerLog.ColorList.Success, true);
 			return true;
 
 		}
@@ -289,7 +285,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			if (playerSelected == null) return false;
 
 			Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été kick.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été kick par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été kick par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 			MissionPeer playerToKick = playerSelected.GetComponent<MissionPeer>();
 			DedicatedCustomServerSubModule.Instance.DedicatedCustomGameServer.KickPlayer(playerToKick.Peer.Id, false);
 			return true;
@@ -305,7 +301,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			MissionPeer playerToKick = playerSelected.GetComponent<MissionPeer>();
 
 			Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été ban.", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été ban par {peer.UserName}", AdminServerLog.ColorList.Success);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été ban par {peer.UserName}", AdminServerLog.ColorList.Success);
 
 			SecurityManager.AddBan(playerSelected.VirtualPlayer);
 
@@ -323,23 +319,18 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 
 			if (playerSelected.IsMuted())
 			{
-
-				GameNetwork.BeginModuleEventAsServer(playerSelected);
-				GameNetwork.WriteMessage(new SendNotification($"Vous avez été démute par un Admin ({peer.UserName}) !", 0));
-				GameNetwork.EndModuleEventAsServer();
+				CommonAdminMsg.SendNotificationToPeerAsServer(playerSelected, $"Vous avez été démute par un Admin ({peer.UserName}) !");
 
 				Log($"[AdminPanel] Le joueur : {playerSelected.UserName} n'est plus mute.", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été retiré des jouers mués par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été retiré des jouers mués par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				SecurityManager.RemoveMute(playerSelected.VirtualPlayer);
 			}
 			else
 			{
-				GameNetwork.BeginModuleEventAsServer(playerSelected);
-				GameNetwork.WriteMessage(new SendNotification($"Vous avez été mute par un Admin ({peer.UserName}) !", 0));
-				GameNetwork.EndModuleEventAsServer();
+				CommonAdminMsg.SendNotificationToPeerAsServer(playerSelected, $"Vous avez été mute par un Admin ({peer.UserName}) !");
 
 				Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été mute.", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été mute par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été mute par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				SecurityManager.AddMute(playerSelected.VirtualPlayer);
 			}
 
@@ -356,13 +347,13 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			if (playerSelected.IsAdmin())
 			{
 				Log($"[AdminPanel] Le joueur : {playerSelected.UserName} n'est plus admin.", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été retiré des admins par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été retiré des admins par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				SecurityManager.RemoveAdmin(playerSelected.VirtualPlayer);
 			}
 			else
 			{
 				Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été promu admin.", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été promu admin par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été promu admin par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				SecurityManager.AddAdmin(playerSelected.VirtualPlayer);
 			}
 
@@ -380,7 +371,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 				}
 				_invulnerable = !_invulnerable;
 				Log($"[AdminPanel] Tous les agents ({Mission.Current?.AllAgents.Count}) ont été rendu {state.ToString()} par l'administrateur {peer.UserName}", LogLevel.Information);
-				SendMessageToClient(peer, $"[Serveur] Tous les agents été rendu {state} par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Tous les agents été rendu {state} par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 				return true;
 			}
 
@@ -390,25 +381,8 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			if (playerSelected != null && playerSelected.ControlledAgent == null) return false;
 			playerSelected.ControlledAgent.ToggleInvulnerable();
 			Log($"[AdminPanel] Le joueur : {playerSelected.UserName} a été rendu {playerSelected.ControlledAgent.CurrentMortalityState} par l'administrateur {peer.UserName}", LogLevel.Information);
-			SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été rendu {playerSelected.ControlledAgent.CurrentMortalityState} par {peer.UserName}", AdminServerLog.ColorList.Success, true);
+			ServerAdminMenuMsg.SendMessageToClient(peer, $"[Serveur] Le joueur {playerSelected.UserName} a été rendu {playerSelected.ControlledAgent.CurrentMortalityState} par {peer.UserName}", AdminServerLog.ColorList.Success, true);
 			return true;
-		}
-
-		private void SendMessageToClient(NetworkCommunicator targetPeer, string message, AdminServerLog.ColorList color, bool forAdmin = false)
-		{
-			if (!forAdmin)
-			{
-				GameNetwork.BeginModuleEventAsServer(targetPeer);
-				GameNetwork.WriteMessage(new AdminServerLog(message, color));
-				GameNetwork.EndModuleEventAsServer();
-			}
-
-			foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
-			{
-				GameNetwork.BeginModuleEventAsServer(peer);
-				GameNetwork.WriteMessage(new AdminServerLog(message, color));
-				GameNetwork.EndModuleEventAsServer();
-			}
 		}
 
 		/// <summary>
@@ -431,7 +405,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			catch (Exception e)
 			{
 				Log($"[AdminPanel] Erreur lors de l'execution de la fonction killPlayers. ({e.Message})", LogLevel.Error);
-				SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction killPlayers.", AdminServerLog.ColorList.Danger, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction killPlayers.", AdminServerLog.ColorList.Danger, true);
 			}
 		}
 
@@ -459,7 +433,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			catch (Exception e)
 			{
 				Log($"[AdminPanel] Erreur lors de l'execution de la fonction godModPlayers. ({e.Message})", LogLevel.Error);
-				SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction godModPlayers.", AdminServerLog.ColorList.Danger, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction godModPlayers.", AdminServerLog.ColorList.Danger, true);
 			}
 		}
 
@@ -483,7 +457,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			catch (Exception e)
 			{
 				Log($"[AdminPanel] Erreur lors de l'execution de la fonction healPlayers. ({e.Message})", LogLevel.Error);
-				SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction healPlayers.", AdminServerLog.ColorList.Danger, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction healPlayers.", AdminServerLog.ColorList.Danger, true);
 			}
 		}
 
@@ -513,7 +487,7 @@ namespace Alliance.Server.Extensions.AdminMenu.Handlers
 			catch (Exception e)
 			{
 				Log($"[AdminPanel] Erreur lors de l'execution de la fonction teleportPlayersToYou. ({e.Message})", LogLevel.Error);
-				SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction teleportPlayersToYou.", AdminServerLog.ColorList.Danger, true);
+				ServerAdminMenuMsg.SendMessageToClient(peer, $"[AdminPanel] Erreur lors de l'execution de la fonction teleportPlayersToYou.", AdminServerLog.ColorList.Danger, true);
 			}
 		}
 

--- a/Alliance.Server/Extensions/AdminMenu/ServerAdminMenuMsg.cs
+++ b/Alliance.Server/Extensions/AdminMenu/ServerAdminMenuMsg.cs
@@ -1,0 +1,25 @@
+﻿using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Server.Extensions.AdminMenu
+{
+	internal static class ServerAdminMenuMsg
+	{
+		public static void SendMessageToClient(NetworkCommunicator targetPeer, string message, AdminServerLog.ColorList color, bool forAdmin = false)
+		{
+			if (!forAdmin)
+			{
+				GameNetwork.BeginModuleEventAsServer(targetPeer);
+				GameNetwork.WriteMessage(new AdminServerLog(message, color));
+				GameNetwork.EndModuleEventAsServer();
+			}
+
+			foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
+			{
+				GameNetwork.BeginModuleEventAsServer(peer);
+				GameNetwork.WriteMessage(new AdminServerLog(message, color));
+				GameNetwork.EndModuleEventAsServer();
+			}
+		}
+	}
+}

--- a/Alliance.Server/Extensions/DieUnderWater/Behaviors/DieUnderWaterBehavior.cs
+++ b/Alliance.Server/Extensions/DieUnderWater/Behaviors/DieUnderWaterBehavior.cs
@@ -1,5 +1,5 @@
-﻿using Alliance.Common.Core.Utils;
-using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
+﻿using Alliance.Client.Extensions.AdminMenu;
+using Alliance.Common.Core.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -240,9 +240,7 @@ namespace Alliance.Server.Extensions.DieUnderWater.Behaviors
 
 					if (agent.MissionPeer != null)
 					{
-						GameNetwork.BeginModuleEventAsServer(agent.MissionPeer.GetNetworkPeer());
-						GameNetwork.WriteMessage(new SendNotification("You are drowning !", 0));
-						GameNetwork.EndModuleEventAsServer();
+						CommonAdminMsg.SendNotificationToPeerAsServer(agent.MissionPeer.GetNetworkPeer(), "You are drowning !");
 					}
 
 					CoreUtils.TakeDamage(agent, 10);

--- a/Alliance.Server/Extensions/SAE/Handlers/SaeGetMakersHandler.cs
+++ b/Alliance.Server/Extensions/SAE/Handlers/SaeGetMakersHandler.cs
@@ -1,6 +1,5 @@
 ﻿using Alliance.Common.Extensions.SAE.Models;
 using Alliance.Common.Extensions.SAE.NetworkMessages.FromClient;
-using Alliance.Common.Extensions.SAE.NetworkMessages.FromServer;
 using Alliance.Server.Extensions.SAE.Behaviors;
 using Alliance.Server.Extensions.SAE.Models;
 using System;
@@ -55,9 +54,7 @@ namespace Alliance.Server.Extensions.SAE.Handlers
 
 					List<SaeMarkerWithIdAndPos> group = markersId.GetRange(startIndex, endIndex - startIndex);
 
-					GameNetwork.BeginModuleEventAsServer(networkPeer);
-					GameNetwork.WriteMessage(new SaeCreateMarkersNetworkServerMessage(group));
-					GameNetwork.EndModuleEventAsServer();
+					SaeMsg.RequestClientToCreateMarkers(networkPeer, group);
 				}
 			}
 		}

--- a/Alliance.Server/Extensions/SAE/SaeMsg.cs
+++ b/Alliance.Server/Extensions/SAE/SaeMsg.cs
@@ -1,0 +1,17 @@
+﻿using Alliance.Common.Extensions.SAE.Models;
+using Alliance.Common.Extensions.SAE.NetworkMessages.FromServer;
+using System.Collections.Generic;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Server.Extensions.SAE
+{
+	internal static class SaeMsg
+	{
+		public static void RequestClientToCreateMarkers(NetworkCommunicator target, List<SaeMarkerWithIdAndPos> groupList)
+		{
+			GameNetwork.BeginModuleEventAsServer(target);
+			GameNetwork.WriteMessage(new SaeCreateMarkersNetworkServerMessage(groupList));
+			GameNetwork.EndModuleEventAsServer();
+		}
+	}
+}

--- a/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Core.Configuration.Models;
+﻿using Alliance.Client.GameModes.PvC;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.Core.ExtendedXML.Extension;
 using Alliance.Common.Core.ExtendedXML.Models;
 using Alliance.Common.Core.Security.Extension;
@@ -233,9 +234,7 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 
 			if (peer.Peer.Communicator.IsConnectionActive)
 			{
-				GameNetwork.BeginBroadcastModuleEvent();
-				GameNetwork.WriteMessage(new SyncGoldsForSkirmish(peer.Peer, newAmount));
-				GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+				PvCMsg.SendSyncGoldMsgToAllPeers(new SyncGoldsForSkirmish(peer.Peer, newAmount));
 			}
 		}
 

--- a/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
+++ b/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
@@ -1,5 +1,5 @@
-﻿using Alliance.Common.Core.Configuration.Models;
-using Alliance.Common.Extensions.AdminMenu.NetworkMessages.FromServer;
+﻿using Alliance.Client.Extensions.AdminMenu;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.Extensions.ShrinkingZone.Behaviors;
 using Alliance.Common.GameModes.BattleRoyale.Behaviors;
 using Alliance.Server.Core;
@@ -83,13 +83,13 @@ namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 			{
 				_spawnStarted = true;
 				spawnBehavior.RequestStartSpawnSession();
-				SendNotificationToAll("Fight will start in 20s...");
+				CommonAdminMsg.SendNotificationToAll("Fight will start in 20s...");
 			}
 			if (_spawnStarted && spawnBehavior.SpawnEnded && !_gameEnded)
 			{
 				if (!_zoneInitialized)
 				{
-					SendNotificationToAll("Fight !");
+					CommonAdminMsg.SendNotificationToAll("Fight !");
 					InitShrinkingZone();
 					_zoneInitialized = true;
 				}
@@ -107,13 +107,13 @@ namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 				{
 					Agent winner = remainingAgents.FirstOrDefault();
 					string winMessage = $"{winner.Name} is the last surviving participant. GG !";
-					SendNotificationToAll(winMessage);
+					CommonAdminMsg.SendNotificationToAll(winMessage);
 					Log(winMessage);
 				}
 				else
 				{
 					string loseMessage = $"Nobody survived... How is that even possible ?";
-					SendNotificationToAll(loseMessage);
+					CommonAdminMsg.SendNotificationToAll(loseMessage);
 					Log(loseMessage);
 				}
 				GameModeStarter.Instance.StartLobby("Lobby", MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
@@ -150,9 +150,7 @@ namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 
 				if (!warningAlreadySentRecently)
 				{
-					GameNetwork.BeginModuleEventAsServer(peer.GetNetworkPeer());
-					GameNetwork.WriteMessage(new SendNotification("Go back into the zone or you'll die !", 0));
-					GameNetwork.EndModuleEventAsServer();
+					CommonAdminMsg.SendNotificationToPeerAsServer(peer.GetNetworkPeer(), "Go back into the zone or you'll die !");
 					_playerWarningTimestamps[peer] = Mission.Current.CurrentTime; // Update last warning time
 				}
 			}

--- a/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRSpawningBehavior.cs
+++ b/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRSpawningBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Extensions.TroopSpawner.Utilities;
+﻿using Alliance.Client.Extensions.AdminMenu;
+using Alliance.Common.Extensions.TroopSpawner.Utilities;
 using Alliance.Server.Extensions.TroopSpawner.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -12,156 +13,156 @@ using static TaleWorlds.MountAndBlade.Agent;
 
 namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 {
-    /// <summary>
-    /// Simple spawn behavior for the Battle Royale.    
-    /// </summary>
-    public class BRSpawningBehavior : SpawningBehaviorBase, ISpawnBehavior
-    {
-        public bool SpawnEnded;
-        private float _lastSpawnCheck;
-        private List<(EquipmentIndex, EquipmentElement)> _altEquipment;
-        private static Random _random = new Random();
-        private static List<float> _values = new List<float> { 0.5f, 1f, 1.5f, 2f, 2.5f };
+	/// <summary>
+	/// Simple spawn behavior for the Battle Royale.    
+	/// </summary>
+	public class BRSpawningBehavior : SpawningBehaviorBase, ISpawnBehavior
+	{
+		public bool SpawnEnded;
+		private float _lastSpawnCheck;
+		private List<(EquipmentIndex, EquipmentElement)> _altEquipment;
+		private static Random _random = new Random();
+		private static List<float> _values = new List<float> { 0.5f, 1f, 1.5f, 2f, 2.5f };
 
-        public BRSpawningBehavior()
-        {
-            // Alternate equipment for heroes
-            EquipmentElement sword = new EquipmentElement(MBObjectManager.Instance.GetObject<ItemObject>("mp_empire_gladius"), null, null, false);
-            _altEquipment = new List<(EquipmentIndex, EquipmentElement)>
-                        {
-                            (EquipmentIndex.Weapon0, sword),
-                            (EquipmentIndex.Weapon1, EquipmentElement.Invalid),
-                            (EquipmentIndex.Weapon2, EquipmentElement.Invalid),
-                            (EquipmentIndex.Weapon3, EquipmentElement.Invalid)
-                        };
-        }
+		public BRSpawningBehavior()
+		{
+			// Alternate equipment for heroes
+			EquipmentElement sword = new EquipmentElement(MBObjectManager.Instance.GetObject<ItemObject>("mp_empire_gladius"), null, null, false);
+			_altEquipment = new List<(EquipmentIndex, EquipmentElement)>
+						{
+							(EquipmentIndex.Weapon0, sword),
+							(EquipmentIndex.Weapon1, EquipmentElement.Invalid),
+							(EquipmentIndex.Weapon2, EquipmentElement.Invalid),
+							(EquipmentIndex.Weapon3, EquipmentElement.Invalid)
+						};
+		}
 
-        public override void RequestStartSpawnSession()
-        {
-            int spawnDuration = 20;
+		public override void RequestStartSpawnSession()
+		{
+			int spawnDuration = 20;
 
-            string spawnBegins = $"Spawn begins. {spawnDuration}s remaining.";
-            Log(spawnBegins, LogLevel.Debug);
-            SendNotificationToAll(spawnBegins);
+			string spawnBegins = $"Spawn begins. {spawnDuration}s remaining.";
+			Log(spawnBegins, LogLevel.Debug);
+			CommonAdminMsg.SendNotificationToAll(spawnBegins);
 
-            base.RequestStartSpawnSession();
+			base.RequestStartSpawnSession();
 
-            Task.Run(() => StopSpawnAfterTimer(spawnDuration * 1000));
-        }
+			Task.Run(() => StopSpawnAfterTimer(spawnDuration * 1000));
+		}
 
-        private async void StopSpawnAfterTimer(int waitTime)
-        {
-            await Task.Delay(waitTime);
-            StopSpawn();
-        }
+		private async void StopSpawnAfterTimer(int waitTime)
+		{
+			await Task.Delay(waitTime);
+			StopSpawn();
+		}
 
-        private void StopSpawn()
-        {
-            IsSpawningEnabled = false;
+		private void StopSpawn()
+		{
+			IsSpawningEnabled = false;
 
 
-            string spawnOver = $"Spawn is over. Be the last alive to win.";
-            Log(spawnOver, LogLevel.Debug);
-            SendNotificationToAll(spawnOver);
+			string spawnOver = $"Spawn is over. Be the last alive to win.";
+			Log(spawnOver, LogLevel.Debug);
+			CommonAdminMsg.SendNotificationToAll(spawnOver);
 
-            // Make everyone mortal once spawn is over
-            foreach (Agent agent in Mission.Current?.AllAgents)
-            {
-                if (agent.CurrentMortalityState != MortalityState.Mortal)
-                {
-                    agent.SetMortalityState(MortalityState.Mortal);
-                }
-            }
-            Mission.AllowAiTicking = true;
+			// Make everyone mortal once spawn is over
+			foreach (Agent agent in Mission.Current?.AllAgents)
+			{
+				if (agent.CurrentMortalityState != MortalityState.Mortal)
+				{
+					agent.SetMortalityState(MortalityState.Mortal);
+				}
+			}
+			Mission.AllowAiTicking = true;
 
-            SpawnEnded = true;
-        }
+			SpawnEnded = true;
+		}
 
-        public override void OnTick(float dt)
-        {
-            if (IsSpawningEnabled)
-            {
-                _lastSpawnCheck += dt;
-                if (_lastSpawnCheck >= 1)
-                {
-                    _lastSpawnCheck = 0;
-                    SpawnAgents();
-                }
-            }
-        }
+		public override void OnTick(float dt)
+		{
+			if (IsSpawningEnabled)
+			{
+				_lastSpawnCheck += dt;
+				if (_lastSpawnCheck >= 1)
+				{
+					_lastSpawnCheck = 0;
+					SpawnAgents();
+				}
+			}
+		}
 
-        public override void Initialize(SpawnComponent spawnComponent)
-        {
-            base.Initialize(spawnComponent);
-        }
+		public override void Initialize(SpawnComponent spawnComponent)
+		{
+			base.Initialize(spawnComponent);
+		}
 
-        protected override void SpawnAgents()
-        {
-            BasicCultureObject culture = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions));
+		protected override void SpawnAgents()
+		{
+			BasicCultureObject culture = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions));
 
-            // Spawn max 20 players at once
-            int playersSpawn = 0;
-            foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
-            {
-                MissionPeer missionPeer = peer.GetComponent<MissionPeer>();
+			// Spawn max 20 players at once
+			int playersSpawn = 0;
+			foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
+			{
+				MissionPeer missionPeer = peer.GetComponent<MissionPeer>();
 
-                if (missionPeer == null || missionPeer.ControlledAgent != null)
-                {
-                    continue;
-                }
-                if (peer.IsSynchronized && (missionPeer.Team == Mission.AttackerTeam || missionPeer.Team == Mission.DefenderTeam))
-                {
-                    BasicCharacterObject basicCharacterObject;
-                    MultiplayerClassDivisions.MPHeroClass mPHeroClassForPeer;
-                    mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).First();
-                    MPPerkObject.MPOnSpawnPerkHandler onSpawnPerkHandler = MPPerkObject.GetOnSpawnPerkHandler(mPHeroClassForPeer.GetAllAvailablePerksForListIndex(0));
+				if (missionPeer == null || missionPeer.ControlledAgent != null)
+				{
+					continue;
+				}
+				if (peer.IsSynchronized && (missionPeer.Team == Mission.AttackerTeam || missionPeer.Team == Mission.DefenderTeam))
+				{
+					BasicCharacterObject basicCharacterObject;
+					MultiplayerClassDivisions.MPHeroClass mPHeroClassForPeer;
+					mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).First();
+					MPPerkObject.MPOnSpawnPerkHandler onSpawnPerkHandler = MPPerkObject.GetOnSpawnPerkHandler(mPHeroClassForPeer.GetAllAvailablePerksForListIndex(0));
 
-                    bool useAltEquipement = true;
-                    basicCharacterObject = mPHeroClassForPeer.TroopCharacter;
-                    //if (PvCRoles.Instance.Commanders.Contains(peer.UserName) || PvCRoles.Instance.Officers.Contains(peer.UserName))
-                    //{
-                    //    mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).GetRandomElementInefficiently();
-                    //    basicCharacterObject = mPHeroClassForPeer.HeroCharacter;
-                    //    useAltEquipement = true;
-                    //}
-                    //else
-                    //{
-                    //    mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).GetRandomElementInefficiently();
-                    //    basicCharacterObject = mPHeroClassForPeer.TroopCharacter;
-                    //}
-                    SpawnHelper.SpawnPlayer(peer, onSpawnPerkHandler, basicCharacterObject, alternativeEquipment: useAltEquipement ? _altEquipment : null, customCulture: culture, mortalityState: MortalityState.Invulnerable);
-                    playersSpawn++;
-                }
-                if (playersSpawn >= 20) break;
-            }
+					bool useAltEquipement = true;
+					basicCharacterObject = mPHeroClassForPeer.TroopCharacter;
+					//if (PvCRoles.Instance.Commanders.Contains(peer.UserName) || PvCRoles.Instance.Officers.Contains(peer.UserName))
+					//{
+					//    mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).GetRandomElementInefficiently();
+					//    basicCharacterObject = mPHeroClassForPeer.HeroCharacter;
+					//    useAltEquipement = true;
+					//}
+					//else
+					//{
+					//    mPHeroClassForPeer = MultiplayerClassDivisions.GetMPHeroClasses(culture).GetRandomElementInefficiently();
+					//    basicCharacterObject = mPHeroClassForPeer.TroopCharacter;
+					//}
+					SpawnHelper.SpawnPlayer(peer, onSpawnPerkHandler, basicCharacterObject, alternativeEquipment: useAltEquipement ? _altEquipment : null, customCulture: culture, mortalityState: MortalityState.Invulnerable);
+					playersSpawn++;
+				}
+				if (playersSpawn >= 20) break;
+			}
 
-            // Spawn bots
-            int nbBotsToSpawnAtt = MultiplayerOptions.OptionType.NumberOfBotsTeam1.GetIntValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions) + MultiplayerOptions.OptionType.NumberOfBotsTeam2.GetIntValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions);
-            while (Mission.AttackerTeam.ActiveAgents.Count() < nbBotsToSpawnAtt)
-            {
-                BasicCharacterObject troopCharacter;
-                //troopCharacter = MultiplayerClassDivisions.GetMPHeroClasses(culture).ToList().GetRandomElement().TroopCharacter;
-                troopCharacter = MultiplayerClassDivisions.GetMPHeroClasses(culture).ToList().First().TroopCharacter;
+			// Spawn bots
+			int nbBotsToSpawnAtt = MultiplayerOptions.OptionType.NumberOfBotsTeam1.GetIntValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions) + MultiplayerOptions.OptionType.NumberOfBotsTeam2.GetIntValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions);
+			while (Mission.AttackerTeam.ActiveAgents.Count() < nbBotsToSpawnAtt)
+			{
+				BasicCharacterObject troopCharacter;
+				//troopCharacter = MultiplayerClassDivisions.GetMPHeroClasses(culture).ToList().GetRandomElement().TroopCharacter;
+				troopCharacter = MultiplayerClassDivisions.GetMPHeroClasses(culture).ToList().First().TroopCharacter;
 
-                // Random difficulty between 0.5 and 2.5f
-                float difficulty = _values[_random.Next(_values.Count)];
-                SpawnHelper.SpawnBot(Mission.AttackerTeam, culture, troopCharacter, botDifficulty: difficulty, mortalityState: MortalityState.Invulnerable);
-            }
-        }
+				// Random difficulty between 0.5 and 2.5f
+				float difficulty = _values[_random.Next(_values.Count)];
+				SpawnHelper.SpawnBot(Mission.AttackerTeam, culture, troopCharacter, botDifficulty: difficulty, mortalityState: MortalityState.Invulnerable);
+			}
+		}
 
-        protected override bool IsRoundInProgress()
-        {
-            return Mission.Current.CurrentState == Mission.State.Continuing;
-        }
+		protected override bool IsRoundInProgress()
+		{
+			return Mission.Current.CurrentState == Mission.State.Continuing;
+		}
 
-        public override bool AllowEarlyAgentVisualsDespawning(MissionPeer missionPeer)
-        {
-            return true;
-        }
+		public override bool AllowEarlyAgentVisualsDespawning(MissionPeer missionPeer)
+		{
+			return true;
+		}
 
-        public bool AllowExternalSpawn()
-        {
-            return IsRoundInProgress();
-        }
-    }
+		public bool AllowExternalSpawn()
+		{
+			return IsRoundInProgress();
+		}
+	}
 }

--- a/Alliance.Server/GameModes/CaptainX/CaptainXMsg.cs
+++ b/Alliance.Server/GameModes/CaptainX/CaptainXMsg.cs
@@ -1,0 +1,42 @@
+﻿using NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Server.GameModes.CaptainX
+{
+	internal static class CaptainXMsg
+	{
+		public static void SendCapturedPointMsgToAllPeers(FlagDominationCapturePointMessage captureFlagMsg)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(captureFlagMsg);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+
+		public static void SendCapturedPointMsgToPeer(NetworkCommunicator target, FlagDominationCapturePointMessage captureFlagMsg)
+		{
+			GameNetwork.BeginModuleEventAsServer(target);
+			GameNetwork.WriteMessage(captureFlagMsg);
+			GameNetwork.EndModuleEventAsServer();
+		}
+
+		public static void SendFlagDominationMoraleChangeMessageToAllPeers(FlagDominationMoraleChangeMessage moraleMsg)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(moraleMsg);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+		public static void SendFlagDominationMoraleChangeMessageToPeer(NetworkCommunicator target, FlagDominationMoraleChangeMessage moralMsg)
+		{
+			GameNetwork.BeginModuleEventAsServer(target);
+			GameNetwork.WriteMessage(moralMsg);
+			GameNetwork.EndModuleEventAsServer();
+		}
+
+		public static void SendFlagDominationFlagsRemovedMessageToAllPeers(FlagDominationFlagsRemovedMessage removeMsg)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(removeMsg);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+	}
+}

--- a/Alliance.Server/GameModes/PvC/Behaviors/PvCSpawningBehavior.cs
+++ b/Alliance.Server/GameModes/PvC/Behaviors/PvCSpawningBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Core.Configuration.Models;
+﻿using Alliance.Client.Extensions.AdminMenu;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.Core.Security.Extension;
 using Alliance.Common.Extensions.ClassLimiter.Models;
 using Alliance.Common.Extensions.ToggleEntities.NetworkMessages.FromServer;
@@ -251,11 +252,11 @@ namespace Alliance.Server.GameModes.PvC.Behaviors
 			{
 				ToggleBarriers(TEMPORARY_BARRIER_TAG, true);
 				await Task.Delay(waitTime - 3000);
-				SendInformationToAll($"Starting in 3...");
+				CommonAdminMsg.SendInformationToAll($"Starting in 3...");
 				await Task.Delay(1000);
-				SendInformationToAll($"Starting in 2...");
+				CommonAdminMsg.SendInformationToAll($"Starting in 2...");
 				await Task.Delay(1000);
-				SendInformationToAll($"Starting in 1...");
+				CommonAdminMsg.SendInformationToAll($"Starting in 1...");
 				await Task.Delay(1000);
 				EnableMortality();
 				ToggleBarriers(TEMPORARY_BARRIER_TAG, false);
@@ -275,7 +276,7 @@ namespace Alliance.Server.GameModes.PvC.Behaviors
 
 		private void EnableMortality()
 		{
-			SendNotificationToAll($"Rappel : le TK est actif, ne frappez pas vos alliés!");
+			CommonAdminMsg.SendNotificationToAll($"Rappel : le TK est actif, ne frappez pas vos alliés!");
 
 			// Make everyone mortal
 			foreach (Agent agent in Mission.Current?.AllAgents)

--- a/Alliance.Server/GameModes/PvC/PvCMsg.cs
+++ b/Alliance.Server/GameModes/PvC/PvCMsg.cs
@@ -1,0 +1,15 @@
+﻿using NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Client.GameModes.PvC
+{
+	public static class PvCMsg
+	{
+		public static void SendSyncGoldMsgToAllPeers(SyncGoldsForSkirmish goldData)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(goldData);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+	}
+}

--- a/Alliance.Server/GameModes/Story/Behaviors/ScenarioBehavior.cs
+++ b/Alliance.Server/GameModes/Story/Behaviors/ScenarioBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Core.Configuration.Models;
+﻿using Alliance.Client.GameModes.PvC;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.Extensions.TroopSpawner.Utilities;
 using Alliance.Common.GameModes.Story.Behaviors;
 using Alliance.Common.GameModes.Story.Models;
@@ -296,9 +297,7 @@ namespace Alliance.Server.GameModes.Story.Behaviors
 
 			if (peer.Peer.Communicator.IsConnectionActive)
 			{
-				GameNetwork.BeginBroadcastModuleEvent();
-				GameNetwork.WriteMessage(new SyncGoldsForSkirmish(peer.Peer, newAmount));
-				GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+				PvCMsg.SendSyncGoldMsgToAllPeers(new SyncGoldsForSkirmish(peer.Peer, newAmount));
 			}
 
 			if (GameModeBaseClient != null)

--- a/Alliance.Server/Patch/HarmonyPatch/Patch_MissionMultiplayerGameModeBase.cs
+++ b/Alliance.Server/Patch/HarmonyPatch/Patch_MissionMultiplayerGameModeBase.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Alliance.Client.GameModes.PvC;
+using HarmonyLib;
 using NetworkMessages.FromServer;
 using System;
 using System.Reflection;
@@ -8,60 +9,58 @@ using static Alliance.Common.Utilities.Logger;
 
 namespace Alliance.Server.Patch.HarmonyPatch
 {
-    class Patch_MissionMultiplayerGameModeBase
-    {
-        private static readonly Harmony Harmony = new Harmony(SubModule.ModuleId + nameof(Patch_MissionMultiplayerGameModeBase));
+	class Patch_MissionMultiplayerGameModeBase
+	{
+		private static readonly Harmony Harmony = new Harmony(SubModule.ModuleId + nameof(Patch_MissionMultiplayerGameModeBase));
 
-        private static bool _patched;
-        public static bool Patch()
-        {
-            try
-            {
-                if (_patched)
-                    return false;
-                _patched = true;
-                Harmony.Patch(
-                    typeof(MissionMultiplayerGameModeBase).GetMethod(nameof(MissionMultiplayerGameModeBase.ChangeCurrentGoldForPeer),
-                        BindingFlags.Instance | BindingFlags.Public),
-                    prefix: new HarmonyMethod(typeof(Patch_MissionMultiplayerGameModeBase).GetMethod(
-                        nameof(Prefix_ChangeCurrentGoldForPeer), BindingFlags.Static | BindingFlags.Public)));
-            }
-            catch (Exception e)
-            {
-                Log($"Alliance - ERROR in {nameof(Patch_MissionMultiplayerGameModeBase)}", LogLevel.Error);
-                Log(e.ToString(), LogLevel.Error);
-                return false;
-            }
+		private static bool _patched;
+		public static bool Patch()
+		{
+			try
+			{
+				if (_patched)
+					return false;
+				_patched = true;
+				Harmony.Patch(
+					typeof(MissionMultiplayerGameModeBase).GetMethod(nameof(MissionMultiplayerGameModeBase.ChangeCurrentGoldForPeer),
+						BindingFlags.Instance | BindingFlags.Public),
+					prefix: new HarmonyMethod(typeof(Patch_MissionMultiplayerGameModeBase).GetMethod(
+						nameof(Prefix_ChangeCurrentGoldForPeer), BindingFlags.Static | BindingFlags.Public)));
+			}
+			catch (Exception e)
+			{
+				Log($"Alliance - ERROR in {nameof(Patch_MissionMultiplayerGameModeBase)}", LogLevel.Error);
+				Log(e.ToString(), LogLevel.Error);
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        // Remove gold limit on ChangeCurrentGoldForPeer
-        public static bool Prefix_ChangeCurrentGoldForPeer(MissionMultiplayerGameModeBase __instance,
-                                                           MissionMultiplayerGameModeBaseClient ___GameModeBaseClient,
-                                                            MissionPeer peer,
-                                                            int newAmount)
-        {
-            newAmount = MBMath.ClampInt(newAmount, 0, CompressionBasic.RoundGoldAmountCompressionInfo.GetMaximumValue());
+		// Remove gold limit on ChangeCurrentGoldForPeer
+		public static bool Prefix_ChangeCurrentGoldForPeer(MissionMultiplayerGameModeBase __instance,
+														   MissionMultiplayerGameModeBaseClient ___GameModeBaseClient,
+															MissionPeer peer,
+															int newAmount)
+		{
+			newAmount = MBMath.ClampInt(newAmount, 0, CompressionBasic.RoundGoldAmountCompressionInfo.GetMaximumValue());
 
-            if (peer.Peer.Communicator.IsConnectionActive)
-            {
-                GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new SyncGoldsForSkirmish(peer.Peer, newAmount));
-                GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
-            }
+			if (peer.Peer.Communicator.IsConnectionActive)
+			{
+				PvCMsg.SendSyncGoldMsgToAllPeers(new SyncGoldsForSkirmish(peer.Peer, newAmount));
+			}
 
-            if (___GameModeBaseClient != null)
-            {
-                ___GameModeBaseClient.OnGoldAmountChangedForRepresentative(peer.Representative, newAmount);
-            }
+			if (___GameModeBaseClient != null)
+			{
+				___GameModeBaseClient.OnGoldAmountChangedForRepresentative(peer.Representative, newAmount);
+			}
 
-            // Skip original method
-            return false;
-        }
+			// Skip original method
+			return false;
+		}
 
 
-        /* Original method 
+		/* Original method 
          * 		
         public void ChangeCurrentGoldForPeer(MissionPeer peer, int newAmount)
         {
@@ -72,9 +71,8 @@ namespace Alliance.Server.Patch.HarmonyPatch
 
             if (peer.Peer.Communicator.IsConnectionActive)
             {
-                GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new SyncGoldsForSkirmish(peer.Peer, newAmount));
-                GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+        
+                PvCMsg.SendSyncGoldMsgToAllPeers(new SyncGoldsForSkirmish(peer.Peer, newAmount));
             }
 
             if (GameModeBaseClient != null)
@@ -82,5 +80,5 @@ namespace Alliance.Server.Patch.HarmonyPatch
                 GameModeBaseClient.OnGoldAmountChangedForRepresentative(peer.Representative, newAmount);
             }
         }*/
-    }
+	}
 }


### PR DESCRIPTION
I would suggest to move any msg into a separated msg static class in order to centralize msg.
It would help to
- Add better structure to the app
- Easily know what messages propose an extension
- Avoid duplicate messages call definition
- Allow to easily see if message are used only inside an extensions or used somewhere else (if this is the case, then some refactor may be needed except if class is a core class for example)

This is currently only made on some of messages.
If approved, then we should refactor more messages in order to extract them in any classes.