### PR TITLE
Rename attribute in Mortality action

### DIFF
--- a/Alliance.Common/GameModes/Story/Actions/MortalityStateZoneAction.cs
+++ b/Alliance.Common/GameModes/Story/Actions/MortalityStateZoneAction.cs
@@ -1,5 +1,5 @@
-﻿using Alliance.Common.GameModes.Story.Models;
-using Alliance.Common.GameModes.Story.Utilities;
+﻿using Alliance.Common.Core.Configuration.Models;
+using Alliance.Common.GameModes.Story.Models;
 using System;
 using static Alliance.Common.GameModes.Story.Conditions.Condition;
 using static TaleWorlds.MountAndBlade.Agent;
@@ -15,7 +15,7 @@ namespace Alliance.Common.GameModes.Story.Actions
 		public SerializableZone Zone;
 		public SideType Side = SideType.All;
 		public TargetType Target = TargetType.All;
-		[ScenarioEditor(label: "Status", tooltip: "Which status is given in this zone.")]
+		[ConfigProperty(label: "Status", tooltip: "Which status is given in this zone.")]
 		public MortalityState State = MortalityState.Invulnerable;
 
 		public MortalityStateZoneAction() { }


### PR DESCRIPTION
ScenarioEditor attribute doesn't exist anymore, it has been merged with ConfigProperty