### PR TITLE
Customs scripts for Editor

### DIFF
--- a/Alliance.Client/_Module/SubModule.xml
+++ b/Alliance.Client/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance" />
   <Name value="Alliance" />
-  <Version value="v0.4.7.0" />
+  <Version value="v0.4.8.0" />
   <ModuleCategory value="Multiplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.Common/CommonProps.props
+++ b/Alliance.Common/CommonProps.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<AllianceVersion>0.4.7.0</AllianceVersion>
+		<AllianceVersion>0.4.8.0</AllianceVersion>
 	</PropertyGroup>
 </Project>

--- a/Alliance.Common/Core/Utils/CoreBehavior.cs
+++ b/Alliance.Common/Core/Utils/CoreBehavior.cs
@@ -23,6 +23,10 @@ namespace Alliance.Common.Core.Utils
 		{
 			if (Mission.Current != null)
 			{
+#if !SERVER
+				EntityUtils.Tick(dt);
+#endif
+
 				SpatialGrid.UpdateGrid(Mission.Current.AllAgents);
 
 #if DEBUG

--- a/Alliance.Common/Core/Utils/EntityUtils.cs
+++ b/Alliance.Common/Core/Utils/EntityUtils.cs
@@ -1,0 +1,421 @@
+﻿using Alliance.Common.Extensions.CustomScripts.Scripts;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Common.Core.Utils
+{
+	/// <summary>
+	/// Helpers for manipulating game entities, generating meshes, etc.
+	/// Uses reflection to access internal engine methods.
+	/// </summary>
+	public static class EntityUtils
+	{
+		// Default glyph map for manipulating ASCII characters (0-127).
+		public static readonly FixedGridGlyphMap DefaultAsciiGrid = new FixedGridGlyphMap(16, 16, 0, 127, 1f, true);
+
+		private const int MAX_TEXT_PANEL_BUILT_PER_TICK = 32;
+
+		private static readonly ConcurrentQueue<CS_TextPanel> _textPanelQueue = new();
+		private static readonly ConcurrentDictionary<CS_TextPanel, byte> _dedupe = new();
+
+		private static bool _initOk;
+		private static object _iGameEntityInstance;
+		private static MethodInfo _miCreateEmpty;
+		private static PropertyInfo _piScenePtr;
+		private static PropertyInfo _piEntityPtr;
+
+		public static void Tick(float dt)
+		{
+			ProcessTextPanelQueue();
+		}
+
+		public static void EnqueueTextPanel(CS_TextPanel panel)
+		{
+			if (panel == null || panel.GameEntity == null) return;
+			if (_dedupe.TryAdd(panel, 0)) _textPanelQueue.Enqueue(panel);
+		}
+
+		private static void ProcessTextPanelQueue()
+		{
+			int built = 0;
+			while (built < MAX_TEXT_PANEL_BUILT_PER_TICK && _textPanelQueue.TryDequeue(out var panel))
+			{
+				_dedupe.TryRemove(panel, out _);
+
+				try
+				{
+					if (panel == null || panel.GameEntity == null)
+						continue;
+
+					// Material resolution (by name) with fallback
+					string materialName = panel.ResolveMaterialName();
+
+					// Build mesh (triangles = white; no vertex color)
+					var mesh = CreateTextMesh(
+						text: panel.Text ?? string.Empty,
+						fontSizeMeters: Math.Max(0.01f, panel.FontSize),
+						panelMaxWidthMeters: panel.PanelMaxWidth,
+						alignment: panel.TextAlignment,
+						glyphMap: DefaultAsciiGrid,
+						materialName: materialName,
+						customColor: panel.GameEntity.GetFactorColor(),
+						letterSpacingEm: panel.LetterSpacing,
+						lineSpacingMult: panel.LineSpacing
+					);
+
+					MetaMesh oldMM = panel.GameEntity.GetMetaMesh(0);
+
+					MetaMesh newMM = MetaMesh.CreateMetaMesh("text_panel_mesh");
+					newMM.AddMesh(mesh);
+					panel.GameEntity.AddComponent(newMM);
+
+					if (oldMM != null) panel.GameEntity.RemoveComponent(oldMM);
+				}
+				catch (Exception e)
+				{
+					Log($"[CS_TextPanelQueue] build error: {e}", LogLevel.Error);
+				}
+
+				built++;
+			}
+		}
+
+		/// <summary>
+		/// Try to get access to the Engine's GameEntity creation method (through internal EngineApplicationInterface)
+		/// </summary>
+		private static bool InitReflection()
+		{
+			if (_initOk) return true;
+
+			try
+			{
+				Assembly engineAsm = typeof(GameEntity).Assembly;
+
+				Type eaiType = engineAsm.GetType("TaleWorlds.Engine.EngineApplicationInterface", false)
+							   ?? engineAsm.GetTypes().FirstOrDefault(t => t.Name == "EngineApplicationInterface")
+							   ?? throw new InvalidOperationException("EngineApplicationInterface type not found.");
+
+				FieldInfo fiIGameEntity = eaiType.GetField("IGameEntity", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+									   ?? throw new MissingFieldException("IGameEntity field not found.");
+
+				_iGameEntityInstance = fiIGameEntity.GetValue(null)
+									   ?? throw new NullReferenceException("IGameEntity instance is null.");
+
+				Type implType = _iGameEntityInstance.GetType();
+
+				_miCreateEmpty = implType
+					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+					.FirstOrDefault(m =>
+					{
+						if (!m.Name.Contains("CreateEmpty")) return false;
+						var ps = m.GetParameters();
+						return ps.Length == 3
+							   && ps[0].ParameterType == typeof(UIntPtr)
+							   && ps[1].ParameterType == typeof(bool)
+							   && ps[2].ParameterType == typeof(UIntPtr);
+					})
+					?? throw new MissingMethodException("CreateEmpty method not found.");
+
+				_piScenePtr = typeof(Scene).GetProperty("Pointer", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+							  ?? throw new MissingMemberException("Scene.Pointer property not found.");
+				_piEntityPtr = typeof(GameEntity).GetProperty("Pointer", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+							   ?? throw new MissingMemberException("GameEntity.Pointer property not found.");
+
+				_initOk = true;
+				return true;
+			}
+			catch (Exception ex)
+			{
+				_initOk = false;
+				Log($"[EditorUtils] Reflection init failed: {ex.Message}", LogLevel.Error);
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Try to create an editable copy of a Game Entity.
+		/// </summary>
+		public static bool TryCreateEditableCopy(Scene scene, GameEntity source, out GameEntity copy)
+		{
+			copy = null;
+			if (!InitReflection())
+			{
+				Log($"[EditorUtils] Failed to access Engine copy method.", LogLevel.Error);
+				return false;
+			}
+
+			try
+			{
+				Dictionary<string, Vec3?> vec2args = new();
+				foreach (GameEntity child in source.GetChildren())
+				{
+					if (!vec2args.ContainsKey(child.Name)) vec2args.Add(child.Name, child.GetMetaMesh(0)?.GetVectorArgument2());
+				}
+
+				UIntPtr scenePtr = (UIntPtr)_piScenePtr.GetValue(scene);
+				UIntPtr srcPtr = (UIntPtr)_piEntityPtr.GetValue(source);
+
+				copy = _miCreateEmpty.Invoke(_iGameEntityInstance, new object[] { scenePtr, true, srcPtr }) as GameEntity;
+				copy.ValidateBoundingBox();
+
+				foreach (GameEntity child in copy.GetChildren())
+				{
+					if (vec2args.TryGetValue(child.Name, out Vec3? vec2) && vec2.HasValue)
+					{
+						child.GetMetaMesh(0)?.SetVectorArgument2(vec2.Value.X, vec2.Value.Y, vec2.Value.Z, vec2.Value.w);
+					}
+				}
+
+				return copy != null;
+			}
+			catch (Exception ex)
+			{
+				Log($"[EditorUtils] Editable copy failed: {ex.Message}.", LogLevel.Error);
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Return entity local size (max - min); falls back to (1,1,1).
+		/// </summary>
+		public static Vec3 GetLocalSizeOrFallback(GameEntity entity)
+		{
+			try
+			{
+				Vec3 min = entity.GetBoundingBoxMin();
+				Vec3 max = entity.GetBoundingBoxMax();
+				Vec3 s = max - min;
+				return new Vec3(
+					Math.Max(s.X, 1e-4f),
+					Math.Max(s.Y, 1e-4f),
+					Math.Max(s.Z, 1e-4f)
+				);
+			}
+			catch (Exception ex)
+			{
+				Log($"[EditorUtils] Failed to get local size of entity: {ex.Message}. Using default size.", LogLevel.Error);
+				return new Vec3(1f, 1f, 1f);
+			}
+		}
+
+		/// <summary>
+		/// Create a text mesh using a glyph map.
+		/// The material must have an atlas texture with glyphs.
+		///	</summary>
+		public static Mesh CreateTextMesh(
+			string text,
+			float fontSizeMeters,
+			float panelMaxWidthMeters,
+			TextHorizontalAlignment alignment,
+			FixedGridGlyphMap glyphMap,
+			string materialName,
+			uint customColor = 0xFFFFFFFF,
+			float letterSpacingEm = 0f,
+			float lineSpacingMult = 1f
+		)
+		{
+			if (string.IsNullOrEmpty(text)) text = "";
+			glyphMap ??= DefaultAsciiGrid;
+
+			float glyphH = Math.Max(0.001f, fontSizeMeters);
+			float glyphW = glyphH * 0.6f;
+			float spacing = letterSpacingEm * glyphW;
+			float lineH = glyphH * Math.Max(0.5f, lineSpacingMult);
+
+			var lines = BreakIntoLines(text, panelMaxWidthMeters, glyphMap, glyphW, spacing);
+
+			var mesh = Mesh.CreateMesh(editable: true);
+			mesh.CullingMode = MBMeshCullingMode.None;
+
+			UIntPtr handle = UIntPtr.Zero;
+			bool locked = false;
+
+			try
+			{
+				mesh.AddEditDataUser();
+				mesh.SetEditDataPolicy(EditDataPolicy.Keep_until_first_render);
+				handle = mesh.LockEditDataWrite();
+				locked = true;
+
+				const uint White = 0xFFFFFFFF;
+
+				for (int li = 0; li < lines.Count; li++)
+				{
+					var L = lines[li];
+					float alignOffsetX = alignment switch
+					{
+						TextHorizontalAlignment.Left => 0f,
+						TextHorizontalAlignment.Center => -L.width * 0.5f,
+						TextHorizontalAlignment.Right => -L.width,
+						_ => 0f
+					};
+
+					float penX = 0f;
+					float z0Line = -li * lineH; // grow downward
+
+					for (int i = L.start; i < L.end; i++)
+					{
+						char ch = L.text[i];
+						if (!glyphMap.TryGetUV(ch, out var uvMin, out var uvMax))
+							glyphMap.TryGetUV('?', out uvMin, out uvMax);
+
+						float adv = glyphMap.AdvanceFor(ch, glyphW);
+
+						float x0 = alignOffsetX + penX;
+						float x1 = x0 + (ch == ' ' ? adv : glyphW);
+						float z0 = z0Line;
+						float z1 = z0 + glyphH;
+
+						var p00 = new Vec3(x0, 0f, z0);
+						var p10 = new Vec3(x1, 0f, z0);
+						var p11 = new Vec3(x1, 0f, z1);
+						var p01 = new Vec3(x0, 0f, z1);
+
+						var t00 = new Vec2(uvMin.x, uvMin.y);
+						var t10 = new Vec2(uvMax.x, uvMin.y);
+						var t11 = new Vec2(uvMax.x, uvMax.y);
+						var t01 = new Vec2(uvMin.x, uvMax.y);
+
+						mesh.AddTriangle(p00, p10, p11, t00, t10, t11, White, handle);
+						mesh.AddTriangle(p00, p11, p01, t00, t11, t01, White, handle);
+
+						bool hasNext = (i + 1) < L.end && L.text[i + 1] != '\n';
+						penX += adv + (hasNext ? spacing : 0f);
+					}
+				}
+			}
+			finally
+			{
+				if (locked) mesh.UnlockEditDataWrite(handle);
+			}
+
+			mesh.RecomputeBoundingBox();
+
+			if (!string.IsNullOrEmpty(materialName))
+			{
+				mesh.SetMaterial(materialName);
+				mesh.Color = customColor;
+			}
+
+			mesh.ReleaseEditDataUser();
+			return mesh;
+		}
+
+		/// <summary>
+		/// Break a raw string into lines based on max width and glyph map.
+		/// </summary>
+		private static List<Line> BreakIntoLines(string raw, float maxWidth, FixedGridGlyphMap glyphMap, float glyphW, float spacing)
+		{
+			List<Line> lines = new List<Line>();
+			if (raw.Length == 0) { lines.Add(new Line(raw, 0, 0, 0f)); return lines; }
+
+			int start = 0;
+			float penX = 0f;
+			int countInLine = 0;
+
+			for (int i = 0; i < raw.Length; i++)
+			{
+				char ch = raw[i];
+
+				if (ch == '\n')
+				{
+					float width = penX - (countInLine > 0 ? spacing : 0f);
+					lines.Add(new Line(raw, start, i, Math.Max(0f, width)));
+					start = i + 1; penX = 0f; countInLine = 0;
+					continue;
+				}
+
+				float adv = glyphMap.AdvanceFor(ch, glyphW);
+				float prospective = penX + adv + (countInLine > 0 ? spacing : 0f);
+
+				bool wrap = maxWidth > 0f && countInLine > 0 && prospective > maxWidth;
+				if (wrap)
+				{
+					float width = penX - (countInLine > 0 ? spacing : 0f);
+					lines.Add(new Line(raw, start, i, Math.Max(0f, width)));
+					start = i; penX = 0f; countInLine = 0;
+				}
+
+				penX += adv + (countInLine > 0 ? spacing : 0f);
+				countInLine++;
+			}
+
+			if (start <= raw.Length)
+			{
+				float width = penX - (countInLine > 0 ? spacing : 0f);
+				lines.Add(new Line(raw, start, raw.Length, Math.Max(0f, width)));
+			}
+
+			return lines;
+		}
+
+		/// <summary>
+		/// A glyph map gives UV coordinates for characters in a fixed grid.
+		/// </summary>
+		public class FixedGridGlyphMap
+		{
+			public readonly int Columns, Rows, StartChar, EndChar;
+			public readonly float SpaceWidthFactor;
+			public readonly bool FlipV;
+
+			public FixedGridGlyphMap(int columns = 16, int rows = 16, int startChar = 0, int endChar = 127, float spaceWidthFactor = 1f, bool flipV = true)
+			{
+				Columns = columns;
+				Rows = rows;
+				StartChar = startChar;
+				EndChar = endChar;
+				SpaceWidthFactor = spaceWidthFactor;
+				FlipV = flipV;
+			}
+
+			public bool TryGetUV(char ch, out Vec2 uvMin, out Vec2 uvMax)
+			{
+				int code = ch;
+				if (code < StartChar || code >= EndChar) code = '?';
+				if (code < StartChar || code >= EndChar) { uvMin = new Vec2(0, 0); uvMax = new Vec2(0, 0); return false; }
+
+				int idx = code - StartChar; int col = idx % Columns; int row = idx / Columns;
+				float u0 = (float)col / Columns, v0 = (float)row / Rows;
+				float u1 = (float)(col + 1) / Columns, v1 = (float)(row + 1) / Rows;
+				if (FlipV) { float nv0 = 1f - v1, nv1 = 1f - v0; v0 = nv0; v1 = nv1; }
+				uvMin = new Vec2(u0, v0); uvMax = new Vec2(u1, v1);
+				return true;
+			}
+
+			public float AdvanceFor(char ch, float glyphWidth)
+			{
+				return ch == ' ' ? glyphWidth * SpaceWidthFactor : glyphWidth;
+			}
+		}
+
+		// Represents a single line of text with its start and end position in the original string
+		private readonly struct Line
+		{
+			public readonly string text;
+			public readonly int start, end;
+			public readonly float width;
+			public Line(string t, int s, int e, float w) { text = t; start = s; end = e; width = w; }
+		}
+
+		public enum TextHorizontalAlignment
+		{
+			Left,
+			Right,
+			Center,
+			Justify
+		}
+
+		public enum AvailableFonts
+		{
+			Galahad,
+			OldLondon,
+			AntiqueOlive
+		}
+	}
+}

--- a/Alliance.Common/Core/Utils/EntityUtils.cs
+++ b/Alliance.Common/Core/Utils/EntityUtils.cs
@@ -205,6 +205,27 @@ namespace Alliance.Common.Core.Utils
 		}
 
 		/// <summary>
+		/// Set the scale of a MatrixFrame directly (instead of multiplying existing scale like native method).
+		/// </summary>
+		public static MatrixFrame SetScale(MatrixFrame m, Vec3 newScale, bool orthonormalize = true)
+		{
+			Mat3 rot = m.rotation;
+
+			if (orthonormalize) rot.Orthonormalize();
+
+			Vec3 s = rot.s; s.Normalize();
+			Vec3 f = rot.f; f.Normalize();
+			Vec3 u = rot.u; u.Normalize();
+
+			// Apply new scale per-axis
+			rot.s = s * newScale.x;
+			rot.f = f * newScale.y;
+			rot.u = u * newScale.z;
+
+			return new MatrixFrame(rot, m.origin);
+		}
+
+		/// <summary>
 		/// Create a text mesh using a glyph map.
 		/// The material must have an atlas texture with glyphs.
 		///	</summary>

--- a/Alliance.Common/Extensions/CustomScripts/Scripts/CS_Array.cs
+++ b/Alliance.Common/Extensions/CustomScripts/Scripts/CS_Array.cs
@@ -1,0 +1,223 @@
+﻿using Alliance.Common.Core.Utils;
+using System.Linq;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Common.Extensions.CustomScripts.Scripts
+{
+	/// <summary>
+	/// Blender-like Array: duplicate objects, apply relative/constant offsets, use optional object offset.
+	/// </summary>
+	public class CS_Array : ScriptComponentBehavior
+	{
+		public string REMINDER = "Save often, can crash anytime";
+		public SimpleButton HOW_TO_USE;
+
+		// Source & count
+		public string EntityToDuplicate = "entity_name";
+		public int Count = 2;
+
+		// Offsets (can be combined)
+		public bool UseRelativeOffset = true;
+		public Vec3 RelativeOffset = new Vec3(1f, 0f, 0f); // Blender default: 1 on X
+
+		public bool UseConstantOffset = false;
+		public Vec3 ConstantOffset = new Vec3(0f, 0f, 0f);
+
+		public bool UseObjectOffset = false;
+		public string ObjectOffsetEntityName = "";
+
+		// Tagging
+		public bool ApplyTag = false;
+		public string TagToApply = "";
+		public bool AddSuffixToTag = false;
+		public int SuffixStartingIndex = 0;
+
+		// UI
+		public SimpleButton GENERATE;
+		public SimpleButton RESET;
+		public bool Live = false;
+
+		private float _lastLiveUpdateTime = 0f;
+		private const float LIVE_UPDATE_INTERVAL = 0.5f;
+		private bool _isGenerating = false;
+		private MatrixFrame _entityPreviousFrame = new MatrixFrame();
+		private MatrixFrame _offsetPreviousFrame = new MatrixFrame();
+
+		// React to properties changes in the editor
+		protected override void OnEditorVariableChanged(string variableName)
+		{
+			if (variableName == nameof(HOW_TO_USE)) { DisplayHowToUse(); return; }
+			if (variableName == nameof(GENERATE)) { Generate(); return; }
+			if (variableName == nameof(RESET)) { Reset(); return; }
+			if (variableName == nameof(Live) && Live) { Generate(); return; }
+			if (Live && IsLiveRelevant(variableName)) Generate();
+		}
+
+		private bool IsLiveRelevant(string propertyName) =>
+			propertyName == nameof(EntityToDuplicate) || propertyName == nameof(Count) ||
+			propertyName == nameof(UseRelativeOffset) || propertyName == nameof(RelativeOffset) ||
+			propertyName == nameof(UseConstantOffset) || propertyName == nameof(ConstantOffset) ||
+			propertyName == nameof(UseObjectOffset) || propertyName == nameof(ObjectOffsetEntityName) ||
+			propertyName == nameof(ApplyTag) || propertyName == nameof(TagToApply) ||
+			propertyName == nameof(AddSuffixToTag) || propertyName == nameof(SuffixStartingIndex);
+
+		protected override void OnEditorTick(float dt)
+		{
+			base.OnEditorTick(dt);
+
+			if (Live && !EntityToDuplicate.IsEmpty())
+			{
+				if (_lastLiveUpdateTime <= LIVE_UPDATE_INTERVAL)
+				{
+					_lastLiveUpdateTime += dt;
+					return;
+				}
+				_lastLiveUpdateTime = 0f;
+
+				GameEntity sourceEntity = Scene.GetFirstEntityWithName(EntityToDuplicate);
+				if (sourceEntity == null) return;
+
+				// Regenerate if source entity moved
+				if (_entityPreviousFrame != sourceEntity.GetGlobalFrame())
+				{
+					_entityPreviousFrame = sourceEntity.GetGlobalFrame();
+					Generate();
+				}
+				// Also regenerate if object offset entity moved
+				else if (UseObjectOffset && !ObjectOffsetEntityName.IsEmpty())
+				{
+					GameEntity offsetEntity = Scene.GetFirstEntityWithName(ObjectOffsetEntityName);
+					if (offsetEntity != null && _offsetPreviousFrame != offsetEntity.GetGlobalFrame())
+					{
+						_offsetPreviousFrame = offsetEntity.GetGlobalFrame();
+						Generate();
+					}
+				}
+			}
+
+		}
+
+		private void DisplayHowToUse()
+		{
+			string message = "================ CS_Array ================\n" +
+				"This script is similar to Blender's \"Array\" modifier.\n" +
+				"1. Set the source entity name.\n" +
+				"2. Specify the number of duplicates.\n" +
+				"3. Choose relative/constant offsets or an object offset. You can mix them.\n" +
+				"4. Optionally apply a tag to each duplicate/and add a suffix.\n" +
+				"5. Click 'Generate' to create the duplicates.\n" +
+				"6. Remove the script once you're satisfied with generation.\n" +
+				"Note: Toggle live mode to regenerate on changes.\n" +
+				"==========================================";
+			Log(message, LogLevel.Information);
+		}
+
+		private void Reset()
+		{
+			GameEntity.RemoveAllChildren();
+			Log("[CS_Array] Reset: removed generated children.", LogLevel.Information);
+		}
+
+		public void Generate()
+		{
+			if (_isGenerating) return;
+			_isGenerating = true;
+
+			try
+			{
+				Reset();
+
+				if (Count <= 0)
+				{
+					Log("[CS_Array] Nothing to generate: Count <= 0.", LogLevel.Warning);
+					return;
+				}
+
+				if (EntityToDuplicate.IsEmpty() || EntityToDuplicate.Contains(' '))
+				{
+					Log("[CS_Array] Invalid EntityToDuplicate name.", LogLevel.Warning);
+					return;
+				}
+
+				GameEntity sourceEntity = Scene.GetFirstEntityWithName(EntityToDuplicate);
+				if (sourceEntity == null)
+				{
+					Log($"[CS_Array] Source '{EntityToDuplicate}' not found.", LogLevel.Warning);
+					return;
+				}
+
+				// Base (original) global frame
+				MatrixFrame sourceFrame = sourceEntity.GetGlobalFrame();
+
+				// Relative offset uses LOCAL mesh size, not transform scale (Blender behavior)
+				Vec3 sizeLocal = EntityUtils.GetLocalSizeOrFallback(sourceEntity);
+
+				// Per-iteration local translation (applied once per step)
+				Vec3 stepLocal = new Vec3(
+					(UseRelativeOffset ? RelativeOffset.X * sizeLocal.X : 0f) + (UseConstantOffset ? ConstantOffset.X : 0f),
+					(UseRelativeOffset ? RelativeOffset.Y * sizeLocal.Y : 0f) + (UseConstantOffset ? ConstantOffset.Y : 0f),
+					(UseRelativeOffset ? RelativeOffset.Z * sizeLocal.Z : 0f) + (UseConstantOffset ? ConstantOffset.Z : 0f)
+				);
+
+				// Object Offset relative (source^-1 * object)
+				MatrixFrame objectOffsetRel = MatrixFrame.Identity;
+				bool useObjectOffset = UseObjectOffset && !string.IsNullOrEmpty(ObjectOffsetEntityName);
+
+				if (useObjectOffset)
+				{
+					GameEntity driver = Scene.GetFirstEntityWithName(ObjectOffsetEntityName);
+					if (driver == null)
+					{
+						useObjectOffset = false;
+						Log($"[CS_Array] ObjectOffset '{ObjectOffsetEntityName}' not found; ignoring.", LogLevel.Warning);
+					}
+					else
+					{
+						objectOffsetRel = sourceFrame.TransformToLocal(driver.GetGlobalFrame());
+					}
+				}
+
+				// Accumulate from the source pose; include original as first duplicate (index 0)
+				MatrixFrame cloneFrame = sourceFrame;
+
+				for (int i = 0; i < Count; i++)
+				{
+					if (i > 0)
+					{
+						if (useObjectOffset) cloneFrame = cloneFrame.TransformToParent(objectOffsetRel); // rotate/scale/translate once
+
+						cloneFrame.origin = cloneFrame.TransformToParent(stepLocal);   // then translate once in local axes
+					}
+
+					// Create editor-modifiable copy
+					if (!EntityUtils.TryCreateEditableCopy(Scene, sourceEntity, out GameEntity clone))
+					{
+						Log($"[CS_Array] Aborting generation, can't copy entity", LogLevel.Error);
+						return;
+					}
+
+					clone.SetGlobalFrame(cloneFrame);
+
+					// Parent under this tool entity for easy cleanup
+					GameEntity.AddChild(clone);
+
+					clone.Name = $"{SuffixStartingIndex + i}_{EntityToDuplicate}";
+
+					if (ApplyTag) clone.AddTag(AddSuffixToTag ? $"{TagToApply}{SuffixStartingIndex + i}" : TagToApply);
+				}
+
+				Log($"[CS_Array] Generated {Count} entities.", LogLevel.Information);
+
+				MBEditor.UpdateSceneTree(); // Refresh editor tree to show new entities
+			}
+			finally
+			{
+				_isGenerating = false;
+			}
+		}
+	}
+}

--- a/Alliance.Common/Extensions/CustomScripts/Scripts/CS_DynamicPile.cs
+++ b/Alliance.Common/Extensions/CustomScripts/Scripts/CS_DynamicPile.cs
@@ -1,0 +1,502 @@
+﻿using Alliance.Common.Core.Utils;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using TaleWorlds.DotNet;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using MathF = TaleWorlds.Library.MathF;
+
+namespace Alliance.Common.Extensions.CustomScripts.Scripts
+{
+	/// <summary>
+	/// Dynamic pile: raises cones with volume, spins + heartbeat,
+	/// and simulates a texture sweep by driving VectorArgument2.Z (0..1)
+	/// on all entities tagged "sweep", synchronized to the heartbeat.
+	/// </summary>
+	public class CS_DynamicPile : MissionObject
+	{
+		public bool Enabled = true;
+
+		// ----- Pile geometry -----
+		public float ConeMaxHeight = 7.77f;
+		public float Cone2MaxHeight = 4.1f;
+		public int ConeMaxVolume = 20000;
+		public int MaxVolumePerSecond = 10;
+		public float EstimateGravity = 8f;
+
+		// ----- Heart spin -----
+		public float HeartSpinBase = 0.2f;
+		public float HeartSpinSpeedMax = 6.0f;
+		public float HeartSpinAccel = 6.0f;
+		public float HeartSpinBrake = 4.0f;
+
+		// ----- Heartbeat -----
+		public float HeartBPMIdle = 40f;   // beats per minute when idle
+		public float HeartBPMActive = 80f;  // beats per minute when active
+		public float HeartBeat1Width = 0.065f;// fraction of cycle (0..1), main beat width
+		public float HeartBeat2Width = 0.050f;// fraction of cycle (0..1), second beat width
+		public float HeartBeat2Delay = 0.18f; // fraction after beat1 (0..1)
+		public float HeartBeat2Gain = 0.6f;  // second beat strength vs first (0..1)
+		public float HeartBeatAmpIdle = 0.04f; // ±4% when idle
+		public float HeartBeatAmpActive = 0.10f; // ±10% when active
+		public float HeartBeatAccel = 6.0f;  // acceleration into active state
+		public float HeartBeatBrake = 4.0f;  // brake into idle state
+
+		// ----- Sweep simulation -----
+		public float SweepScaleX = 0.5f;
+		public float SweepScaleY = 1.0f;
+		public float SweepOffsetX = 0.0f; // drift offset added to sweep (SweepMin..SweepMax)
+		public float SweepOffsetY = 0.0f;
+		public float SweepMin = 0.0f;
+		public float SweepMax = 1.0f;
+
+		// Editor buttons
+		[EditableScriptComponentVariable(true)] public SimpleButton INIT;
+		[EditableScriptComponentVariable(true)] public SimpleButton RESET;
+		[EditableScriptComponentVariable(true)] public SimpleButton ADD;
+		[EditableScriptComponentVariable(true)] public SimpleButton REMOVE;
+
+		// ----- Volume state -----
+		public float CurrentVolume = 0f;
+		public float VolumeToAdd = 0f;
+		private float _volumeTargetted;
+		private float _lastVolumeAdded;
+		private float _currentVolumeEstimate = 0f;
+		private float _volumeDisplayed = 0f;
+
+		// ----- Entities -----
+		private GameEntity _coneEntity;
+		private MatrixFrame _initialConeFrame;
+		private float _initialConeZ;
+		private float _currentConeZ;
+
+		private GameEntity _cone2Entity;
+		private MatrixFrame _initialCone2Frame;
+		private float _initialCone2Z;
+		private float _currentCone2Z;
+
+		private GameEntity _particleEntity;
+		private ParticleSystem _particleSystem;
+		private MatrixFrame _initialParticleFrame;
+
+		private GameEntity _heartEntity;
+		private MatrixFrame _initialHeartFrame;
+
+		private List<GameEntity> _entitiesToSweep;
+
+		private CS_TextPanel _textPanel;
+		private NumberFormatInfo _labelFormat;
+
+		// ----- Rise timing -----
+		private float _riseDelayRequired = 0f;
+		private float _riseDelayTimer = 0f;
+		private bool _isRising = false;
+
+		// ----- Emitter -----
+		private float _currentEmitterRate = 0f; // 0..1 normalized
+		private float _emitterLifeTimer = 0f;
+
+		// ----- Spin state -----
+		private float _heartSpinVel = 0f;
+		private float _heartSpinAng = 0f;
+
+		// ----- Heartbeat state -----
+		private float _beatPhase = 0f;  // wraps [0..1)
+		private float _beatHz = 1f;     // beats per second (smoothed)
+		private float _beatAmp = 0f;    // amplitude (smoothed)
+		private float _heartBeatScale = 1f;
+
+		private const float _Eps = 1e-5f;
+
+		public CS_DynamicPile() { }
+
+		public void Init()
+		{
+			InitChildren();
+			_beatPhase = 0f;
+			_labelFormat = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+			_labelFormat.NumberGroupSeparator = " ";
+			_labelFormat.NumberDecimalDigits = 0;
+		}
+
+		/// <summary>
+		/// Set the current volume immediately, without animation.
+		/// </summary>
+		public void SetVolume(float newVolume)
+		{
+			CurrentVolume = newVolume;
+			_currentVolumeEstimate = CurrentVolume;
+			_volumeTargetted = CurrentVolume;
+			UpdateCones();
+		}
+
+		/// <summary>
+		/// Set target volume, which will make the pile rise according to settings.
+		/// </summary>
+		public void SetVolumeTarget(float targetVolume)
+		{
+			RecomputeRiseDelay();
+			_volumeTargetted = targetVolume;
+		}
+
+		public void Reset()
+		{
+			CurrentVolume = 0f;
+			_currentVolumeEstimate = 0f;
+			_volumeTargetted = 0f;
+			_currentEmitterRate = 0f;
+			_riseDelayTimer = 0f;
+			_isRising = false;
+
+			_heartSpinVel = 0f;
+			_heartSpinAng = 0f;
+
+			_beatPhase = 0f;
+			UpdateCones();
+		}
+
+		protected override void OnInit()
+		{
+			base.OnInit();
+			Init();
+		}
+
+		protected override void OnEditorInit()
+		{
+			base.OnEditorInit();
+			Init();
+		}
+
+		private void InitChildren()
+		{
+			_coneEntity = GameEntity.GetFirstChildEntityWithTag("pile");
+			if (_coneEntity != null)
+			{
+				_initialConeFrame = _coneEntity.GetGlobalFrame();
+				_initialConeZ = _initialConeFrame.origin.Z;
+				_currentConeZ = _initialConeZ;
+			}
+
+			_cone2Entity = GameEntity.GetFirstChildEntityWithTag("pile2");
+			if (_cone2Entity != null)
+			{
+				_initialCone2Frame = _cone2Entity.GetGlobalFrame();
+				_initialCone2Z = _initialCone2Frame.origin.Z;
+				_currentCone2Z = _initialCone2Z;
+			}
+
+			_particleEntity = GameEntity.GetFirstChildEntityWithTag("particle");
+			if (_particleEntity != null)
+			{
+				_initialParticleFrame = _particleEntity.GetGlobalFrame();
+				var comp = _particleEntity.GetComponentAtIndex(0, GameEntity.ComponentType.ParticleSystemInstanced);
+				if (comp is ParticleSystem ps)
+				{
+					_particleSystem = ps;
+					_particleSystem.SetRuntimeEmissionRateMultiplier(_currentEmitterRate);
+				}
+			}
+
+			_heartEntity = GameEntity.GetFirstChildEntityWithTag("heart");
+			if (_heartEntity != null) _initialHeartFrame = _heartEntity.GetGlobalFrame();
+
+			_entitiesToSweep = GameEntity.CollectChildrenEntitiesWithTag("sweep");
+
+			_textPanel = GameEntity.GetFirstScriptInFamilyDescending<CS_TextPanel>();
+		}
+
+		protected override void OnEditorVariableChanged(string variableName)
+		{
+			switch (variableName)
+			{
+				case nameof(INIT): Init(); break;
+				case nameof(RESET): Reset(); break;
+				case nameof(ADD): AddVolume(); break;
+				case nameof(REMOVE): RemoveVolume(); break;
+			}
+		}
+
+		public override TickRequirement GetTickRequirement()
+		{
+			return TickRequirement.Tick | base.GetTickRequirement();
+		}
+
+		protected override void OnTick(float dt)
+		{
+			base.OnTick(dt);
+			Tick(dt);
+		}
+
+		protected override void OnEditorTick(float dt)
+		{
+			base.OnEditorTick(dt);
+			Tick(dt);
+		}
+
+		private void Tick(float dt)
+		{
+			if (!Enabled) return;
+
+			if (_volumeTargetted != CurrentVolume)
+			{
+				if (!_isRising)
+				{
+					_riseDelayTimer += dt;
+					if (_riseDelayTimer >= _riseDelayRequired) _isRising = true;
+				}
+
+				_emitterLifeTimer += dt;
+				UpdateEmitterRate();
+				UpdateVolumeEstimate(dt);
+
+				UpdateHeartSpin(dt);
+				UpdateHeartBeat(dt);
+				UpdateBranchSweeps();
+				UpdateParticleAndHeart(dt);
+
+				if (_isRising)
+				{
+					UpdateVolume(dt);
+					UpdateCones();
+				}
+			}
+			else
+			{
+				_riseDelayTimer = 0f;
+				_isRising = false;
+				_emitterLifeTimer = 0f;
+				_currentVolumeEstimate = CurrentVolume;
+
+				UpdateTextLabel();
+
+				UpdateHeartSpin(dt);
+				UpdateHeartBeat(dt);
+				UpdateBranchSweeps();
+
+				if (_currentEmitterRate != 0f) _currentEmitterRate = 0f;
+				UpdateParticleAndHeart(dt);
+			}
+		}
+
+		private void UpdateTextLabel()
+		{
+			if (_textPanel != null && _volumeDisplayed != CurrentVolume)
+			{
+				_volumeDisplayed = CurrentVolume;
+
+				_textPanel.Text = (CurrentVolume * 1000f).ToString("N", _labelFormat) + " E";
+				_textPanel.Render();
+			}
+		}
+
+		// Editor only command - Simulate adding volume
+		private void AddVolume()
+		{
+			RecomputeRiseDelay();
+			_volumeTargetted += VolumeToAdd;
+			if (_volumeTargetted > ConeMaxVolume) _volumeTargetted = ConeMaxVolume;
+		}
+
+		// Editor only command - Simulate removing volume
+		private void RemoveVolume()
+		{
+			CurrentVolume = _volumeTargetted;
+			_volumeTargetted -= VolumeToAdd;
+			if (_volumeTargetted < 0f) _volumeTargetted = 0f;
+		}
+
+		private void RecomputeRiseDelay()
+		{
+			float pileTopZ = _coneEntity.GetGlobalFrame().origin.z + ConeMaxHeight;
+			float emitterZ = _particleEntity.GetGlobalFrame().origin.z;
+			float dz = emitterZ - pileTopZ;
+			_riseDelayRequired = dz <= 0f ? 0f : Math.Max(0f, (float)Math.Sqrt(2f * dz / EstimateGravity));
+			_riseDelayTimer = 0f;
+			_isRising = false;
+		}
+
+		private void UpdateCones()
+		{
+			float h = ConeMaxHeight * (float)Math.Pow(CurrentVolume / Math.Max(1f, ConeMaxVolume), 0.5f);
+
+			if (_coneEntity != null)
+			{
+				_currentConeZ = _initialConeZ + h;
+				MatrixFrame f = _coneEntity.GetGlobalFrame();
+				f.origin = new Vec3(f.origin.x, f.origin.y, _currentConeZ);
+				_coneEntity.SetGlobalFrame(f);
+			}
+
+			if (_cone2Entity != null)
+			{
+				float pct = (_currentConeZ - _initialConeZ) / Math.Max(_Eps, ConeMaxHeight);
+				_currentCone2Z = _initialCone2Z + Cone2MaxHeight * pct;
+				MatrixFrame f = _cone2Entity.GetGlobalFrame();
+				f.origin = new Vec3(f.origin.x, f.origin.y, _currentCone2Z);
+				_cone2Entity.SetGlobalFrame(f);
+			}
+		}
+
+		private void UpdateParticleAndHeart(float dt)
+		{
+			float t = _currentVolumeEstimate / Math.Max(1f, ConeMaxVolume);
+			float elevation = (float)(ConeMaxHeight * 2f * Math.Pow(t, 0.5f));
+
+			float initScaleP = _initialParticleFrame.GetScale().x;
+			float initScaleH = _initialHeartFrame.GetScale().x;
+			Vec3 delta = _initialHeartFrame.origin - _initialParticleFrame.origin;
+
+			// Particle
+			MatrixFrame particleFrame = _initialParticleFrame;
+			particleFrame.origin = new Vec3(particleFrame.origin.x, particleFrame.origin.y, particleFrame.origin.z + elevation);
+			float sp = MathF.Lerp(initScaleP, .5f, t);
+			particleFrame = EntityUtils.SetScale(particleFrame, new Vec3(sp, sp, sp));
+			particleFrame.Rotate(_heartSpinAng, Vec3.Up);
+			_particleEntity?.SetGlobalFrame(in particleFrame);
+
+			// Heart
+			if (_heartEntity != null)
+			{
+				MatrixFrame heartFrame = _initialHeartFrame;
+				float baseScaleH = MathF.Lerp(initScaleH, .5f, t);
+				float relScale = baseScaleH / Math.Max(1e-6f, initScaleH);
+				Vec3 offset = delta * relScale;
+
+				// Maintain a relative distance above the particles
+				heartFrame.origin = particleFrame.origin + offset;
+
+				float finalScaleH = baseScaleH * _heartBeatScale;
+				heartFrame = EntityUtils.SetScale(heartFrame, new Vec3(finalScaleH, finalScaleH, finalScaleH));
+				heartFrame.Rotate(_heartSpinAng, Vec3.Up);
+				_heartEntity.SetGlobalFrame(in heartFrame);
+			}
+
+			_particleSystem?.SetRuntimeEmissionRateMultiplier(_currentEmitterRate);
+		}
+
+		private void UpdateHeartSpin(float dt)
+		{
+			bool active = _currentEmitterRate > 0.01f || _currentVolumeEstimate != _volumeTargetted;
+			float estimatedVolumePercentage = _currentVolumeEstimate / Math.Max(1f, ConeMaxVolume);
+			float tEase = EaseInOut(MathF.Clamp(estimatedVolumePercentage, 0f, 1f));
+			float emitBoost = MathF.Clamp(_currentEmitterRate, 0f, 1f);
+			float boost = Math.Max(tEase, emitBoost * 0.75f);
+
+			float targetVel = HeartSpinBase + (HeartSpinSpeedMax - HeartSpinBase) * boost;
+			float target = active ? targetVel : HeartSpinBase;
+			float resp = active ? HeartSpinAccel : HeartSpinBrake;
+
+			_heartSpinVel = SmoothTowards(_heartSpinVel, target, resp, dt);
+			_heartSpinAng += _heartSpinVel * dt;
+			if (_heartSpinAng > Math.PI * 4f) _heartSpinAng -= (float)(Math.PI * 4f);
+		}
+
+		private void UpdateHeartBeat(float dt)
+		{
+			bool active = _isRising || _currentEmitterRate > 0.01f || _currentVolumeEstimate != _volumeTargetted;
+
+			// Targets: frequency from BPM, amplitude from state
+			float targetHz = (active ? HeartBPMActive : HeartBPMIdle) / 60f; // beats/sec
+			float targetAmp = active ? HeartBeatAmpActive : HeartBeatAmpIdle;
+
+			// Smooth towards targets
+			float resp = active ? HeartBeatAccel : HeartBeatBrake;
+			_beatHz = SmoothTowards(_beatHz, targetHz, resp, dt);
+			_beatAmp = SmoothTowards(_beatAmp, targetAmp, resp, dt);
+
+			// Advance wrapped phase in [0..1)
+			_beatPhase += Math.Max(0f, _beatHz) * dt;
+			if (_beatPhase >= 1f) _beatPhase -= (float)Math.Floor(_beatPhase);
+
+			// Build a "lub-dub" pulse: one strong + one smaller, short delay later
+			// Use wrapped Gaussians so pulses are sharp, with quiet time between.
+			float p1 = GaussianPulseWrapped(_beatPhase, 0.00f, HeartBeat1Width); // main beat
+			float p2 = GaussianPulseWrapped(_beatPhase, HeartBeat2Delay, HeartBeat2Width) * HeartBeat2Gain; // second beat
+
+			// Shaping to make the hit feel snappier
+			float pulse = p1 + p2; // ≈ 0 most of the time, spikes on beats
+			pulse = PowSaturate(pulse, 0.6f); // <1 → sharper peaks, >1 → softer
+
+			// Final scale multiplier (center at 1.0, only expands on beats)
+			_heartBeatScale = 1f + _beatAmp * pulse;  // e.g. 1.00 → 1.10 at peaks
+		}
+
+		private void UpdateBranchSweeps()
+		{
+			// Map to [Min..Max]
+			float sweepX = SweepOffsetX + MathF.Lerp(SweepMin, SweepMax, _beatPhase);
+
+			foreach (GameEntity entity in _entitiesToSweep)
+			{
+				MetaMesh mm = entity.GetMetaMesh(0);
+				mm?.SetVectorArgument2(SweepScaleX, SweepScaleY, sweepX, SweepOffsetY);
+			}
+		}
+
+		private void UpdateVolume(float dt)
+		{
+			float maxPerTick = MaxVolumePerSecond * dt;
+			float delta = _volumeTargetted - CurrentVolume;
+			_lastVolumeAdded = Math.Min(delta, maxPerTick);
+			CurrentVolume += _lastVolumeAdded;
+		}
+
+		private void UpdateVolumeEstimate(float dt)
+		{
+			float maxPerTick = MaxVolumePerSecond * dt;
+			float delta = _volumeTargetted - _currentVolumeEstimate;
+			_lastVolumeAdded = Math.Min(delta, maxPerTick);
+			_currentVolumeEstimate += _lastVolumeAdded;
+		}
+
+		private void UpdateEmitterRate()
+		{
+			if (MaxVolumePerSecond <= 0) return;
+
+			float currentVolume = Math.Max(CurrentVolume, _currentVolumeEstimate);
+
+			float avgRate = Math.Min(_volumeTargetted - currentVolume, MaxVolumePerSecond) / MaxVolumePerSecond;
+
+			// Don’t drop if it's been less than a second, to have correct amount emitted
+			if (avgRate < _currentEmitterRate && _emitterLifeTimer < 1f) return;
+			_currentEmitterRate = avgRate;
+			_emitterLifeTimer = 0f;
+		}
+
+		private static float GaussianPulseWrapped(float phase01, float center01, float width01)
+		{
+			// Short, wrapped distance on the unit circle
+			float distance = phase01 - center01;
+			float wrappedDistance = distance - (float)Math.Floor(distance);
+			wrappedDistance = Math.Abs(wrappedDistance);
+			wrappedDistance = Math.Min(wrappedDistance, 1f - wrappedDistance); // shortest distance around the circle
+
+			// Gaussian with sigma ~ width01/2 (tweak factor 2.0 for sharpness)
+			float sigma = Math.Max(1e-4f, width01 * 0.5f);
+			float g = (float)Math.Exp(-(wrappedDistance * wrappedDistance) / (2f * sigma * sigma));
+			return g;
+		}
+
+		// Raises v to power k but keeps 0..1 clamped
+		private static float PowSaturate(float v, float k)
+		{
+			v = v < 0f ? 0f : (v > 1f ? 1f : v);
+			return (float)Math.Pow(v, k);
+		}
+
+		private static float SmoothTowards(float current, float target, float responsiveness, float dt)
+		{
+			double k = Math.Max(0.0, responsiveness);
+			double a = 1.0 - Math.Exp(-k * dt);
+			return current + (float)((target - current) * a);
+		}
+
+		private static float EaseInOut(float x)
+		{
+			x = MathF.Clamp(x, 0f, 1f);
+			return (x < 0.5f) ? 4f * x * x * x : 1f - (float)Math.Pow(-2f * x + 2f, 3f) / 2f;
+		}
+	}
+}

--- a/Alliance.Common/Extensions/CustomScripts/Scripts/CS_EditorFixer.cs
+++ b/Alliance.Common/Extensions/CustomScripts/Scripts/CS_EditorFixer.cs
@@ -1,0 +1,547 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using TaleWorlds.Engine;
+using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
+using TaleWorlds.ModuleManager;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+using Path = System.IO.Path;
+
+namespace Alliance.Common.Extensions.CustomScripts.Scripts
+{
+	/// <summary>
+	/// A script to fix some editor issues...
+	/// </summary>
+	public class CS_EditorFixer : ScriptComponentBehavior
+	{
+		private static Dictionary<string, List<PrefabArg2>> _prefabToArg2 = new();
+		private static GameEntity _lastSelectedEntity;
+
+		public string REMINDER = "Save often, can crash anytime";
+
+		public SimpleButton I_APPLY_ARG2_README;
+		public string PrefabFile = "al_nat_deco.xml";
+		public SimpleButton LOAD_PREFABS;
+		public SimpleButton APPLY_ARG2_FROM_PREFABS;
+		public bool AutoApplyOnSelect = false;
+		public bool AutoBreak = false;
+
+		public SimpleButton II_SAVE_ARG2_README;
+		public bool EnableArg2Saving = false;
+
+		protected override void OnEditorVariableChanged(string variableName)
+		{
+			if (variableName == nameof(I_APPLY_ARG2_README)) { DisplayApplyArg2Readme(); return; }
+			if (variableName == nameof(LOAD_PREFABS)) { LoadPrefabs(); return; }
+			if (variableName == nameof(APPLY_ARG2_FROM_PREFABS)) { ApplyArg2FromPrefabs(); return; }
+			if (variableName == nameof(II_SAVE_ARG2_README)) { DisplaySaveArg2Readme(); return; }
+		}
+
+		protected override void OnEditorTick(float dt)
+		{
+			base.OnEditorTick(dt);
+
+			if (!AutoApplyOnSelect && !EnableArg2Saving) return;
+
+			// If the last selected entity is still selected, no need to check again
+			if (_lastSelectedEntity != null && _lastSelectedEntity.Scene != null && _lastSelectedEntity.IsSelectedOnEditor()
+				&& !(EnableArg2Saving && Input.IsKeyDown(InputKey.LeftControl) && Input.IsKeyPressed(InputKey.N)))
+			{
+				return;
+			}
+
+			List<GameEntity> entities = new();
+			MBEditor._editorScene?.GetEntities(ref entities);
+
+			foreach (GameEntity entity in entities)
+			{
+				if (entity.IsSelectedOnEditor())
+				{
+					if (EnableArg2Saving && Input.IsKeyDown(InputKey.LeftControl) && Input.IsKeyPressed(InputKey.N))
+					{
+						SaveEntityArg2ToPrefab(entity);
+					}
+					else if (_lastSelectedEntity != entity && AutoApplyOnSelect)
+					{
+						CheckVectorArgument(entity);
+					}
+					_lastSelectedEntity = entity;
+					Log($"Selected {entity.Name}");
+					return;
+				}
+			}
+		}
+
+		private void DisplayApplyArg2Readme()
+		{
+			string message =
+				"================ CS_EditorFixer ================\n" +
+				"This script intends to help fix flaws in the Modding Kit.\n" +
+				"- Missing Argument2 in MetaMesh when importing a prefab :\n" +
+				"  1) Set your prefab file name (file must be in Alliance.Editor/Prefabs)\n" +
+				"  2) Click 'LOAD_PREFABS' \n" +
+				"  3) Then either :\n" +
+				"     - Click 'APPLY_ARG2_FROM_PREFABS' to fix all entities in the editor scene\n" +
+				"     - Enable AutoApplyOnSelect to fix the selected entity automatically\n" +
+				"  (RECOMMENDED) Enable AutoBreak to break prefab after applying.\n" +
+				"  Otherwise, the fixed values may not be saved in the scene.\n" +
+				"==========================================";
+			Log(message, LogLevel.Information);
+		}
+
+		private void DisplaySaveArg2Readme()
+		{
+			string message =
+				"================ CS_EditorFixer ================\n" +
+				"This script intends to help fix flaws in the Modding Kit.\n" +
+				"- Saving Argument2 in MetaMesh when exporting a prefab :\n" +
+				"  1) Enable EnableArg2Saving\n" +
+				"  2) After saving your prefab, press CTRL+N to also save the Argument2\n" +
+				"  (The fixed file is written to PrefabsWithFixedArg2/ and does NOT touch the original.)\n" +
+				"==========================================";
+			Log(message, LogLevel.Information);
+		}
+
+		private void LoadPrefabs()
+		{
+			string modulePath = ModuleHelper.GetModuleFullPath(SubModule.CurrentModuleName);
+			_prefabToArg2 = PrefabArg2Helper.IndexPrefabsWithOverrides(modulePath, PrefabFile);
+			string basePath = Path.Combine(modulePath, "Prefabs", PrefabFile);
+			string overPath = Path.Combine(modulePath, "PrefabsWithFixedArg2", PrefabFile);
+			Log($"CS_EditorFixer - Loaded {_prefabToArg2.Count} prefabs. Base: {basePath} | Override (preferred if present): {overPath}");
+		}
+
+		private void ApplyArg2FromPrefabs()
+		{
+			List<GameEntity> entities = new();
+			MBEditor._editorScene?.GetEntities(ref entities);
+			Log($"Found {entities.Count} entities in the editor scene. Checking for VectorArgument2 fixes...");
+			foreach (GameEntity entity in entities)
+				CheckVectorArgument(entity);
+		}
+
+		private void SaveEntityArg2ToPrefab(GameEntity entity)
+		{
+			List<PrefabArg2> entries = PrefabArg2Helper.CollectRuntimeArg2(entity);
+			if (entries.Count == 0)
+			{
+				Log($"[EditorFixer] No argument2 found on '{entity.Name}' hierarchy. Nothing to save.", LogLevel.Information);
+				return;
+			}
+
+			string modulePath = ModuleHelper.GetModuleFullPath(SubModule.CurrentModuleName);
+			string prefabsRoot = Path.Combine(modulePath, "Prefabs");
+			string xmlPath = PrefabArg2Helper.TryFindPrefabXml(prefabsRoot, entity.Name);
+
+			if (string.IsNullOrEmpty(xmlPath))
+			{
+				Log($"[EditorFixer] Could not find prefab XML for '{entity.Name}' under '{prefabsRoot}'.", LogLevel.Warning);
+				return;
+			}
+
+			// writes to PrefabsWithFixedArg2/<same file name>.xml
+			(int updated, int added, string outPath) = PrefabArg2Helper.UpdatePrefabFile(xmlPath, entity.Name, entries);
+
+			// Refresh in-memory map to immediately use the NEW values for Apply/AutoApply
+			List<PrefabArg2> refreshed = PrefabArg2Helper.IndexSinglePrefabFromFile(outPath, entity.Name);
+			if (refreshed != null && refreshed.Count > 0)
+				_prefabToArg2[entity.Name] = refreshed;
+
+			Log($"[EditorFixer] Wrote fixed copy to '{outPath}' for prefab '{entity.Name}'. Updated: {updated}, Added: {added}.", LogLevel.Information);
+		}
+
+		private void CheckVectorArgument(GameEntity entity)
+		{
+			if (entity == null || string.IsNullOrEmpty(entity.Name) || _prefabToArg2 == null || _prefabToArg2.Count == 0) return;
+			if (!_prefabToArg2.TryGetValue(entity.Name, out List<PrefabArg2> entries) || entries.Count == 0) return;
+
+			PrefabArg2Helper.ApplyArg2Recursive(entity, entries);
+
+			if (AutoBreak)
+			{
+				entity.BreakPrefab();
+				Log($"Auto-broke prefab {entity.Name}");
+			}
+		}
+	}
+
+	/// <summary>
+	/// Prefab Arg2 utilities: index a prefab file, apply to runtime entities, and write a safe copy with Arg2 injected.
+	/// </summary>
+	public static class PrefabArg2Helper
+	{
+		public static Dictionary<string, List<PrefabArg2>> IndexPrefabsWithOverrides(string modulePath, string prefabFile)
+		{
+			var result = new Dictionary<string, List<PrefabArg2>>(StringComparer.OrdinalIgnoreCase);
+
+			string basePath = Path.Combine(modulePath, "Prefabs", prefabFile);
+			string overridePath = Path.Combine(modulePath, "PrefabsWithFixedArg2", prefabFile);
+
+			// 1) load base file (if present)
+			if (File.Exists(basePath))
+			{
+				var baseMap = IndexAllPrefabsInFile(basePath);
+				foreach (var kv in baseMap)
+					result[kv.Key] = kv.Value;
+			}
+
+			// 2) load override file (if present) and PREFER its entries
+			if (File.Exists(overridePath))
+			{
+				var overMap = IndexAllPrefabsInFile(overridePath);
+				foreach (var kv in overMap)
+					result[kv.Key] = kv.Value; // override wins
+			}
+
+			return result;
+		}
+
+		/// <summary>Index a single prefab root from a specific file (used to refresh after save).</summary>
+		public static List<PrefabArg2> IndexSinglePrefabFromFile(string xmlPath, string prefabName)
+		{
+			if (!File.Exists(xmlPath)) return new List<PrefabArg2>();
+			XDocument doc = XDocument.Load(xmlPath);
+			XElement root = doc.Root;
+			if (root == null) return new List<PrefabArg2>();
+
+			XElement prefabRoot = root.Elements("game_entity")
+				.FirstOrDefault(ge => string.Equals((string)ge.Attribute("name"), prefabName, StringComparison.Ordinal));
+			if (prefabRoot == null) return new List<PrefabArg2>();
+
+			var entries = new List<PrefabArg2>();
+			CollectEntityArg2Recursive(prefabRoot, new List<int>(), entries);
+			return entries;
+		}
+
+		// ---------- INDEX ----------
+		public static Dictionary<string, List<PrefabArg2>> IndexAllPrefabsInFile(string xmlPath)
+		{
+			var result = new Dictionary<string, List<PrefabArg2>>(StringComparer.OrdinalIgnoreCase);
+			if (!File.Exists(xmlPath)) return result;
+
+			XDocument doc = XDocument.Load(xmlPath);
+			XElement root = doc.Root;
+			if (root == null) return result;
+
+			foreach (XElement prefabRoot in root.Elements("game_entity"))
+			{
+				string prefabName = (string)prefabRoot.Attribute("name") ?? string.Empty;
+				if (string.IsNullOrEmpty(prefabName)) continue;
+
+				var entries = new List<PrefabArg2>();
+				CollectEntityArg2Recursive(prefabRoot, new List<int>(), entries);
+
+				if (entries.Count > 0)
+					result[prefabName] = entries;
+			}
+			return result;
+		}
+
+		private static void CollectEntityArg2Recursive(XElement ge, List<int> indices, List<PrefabArg2> outEntries)
+		{
+			XElement comps = ge.Element("components");
+			if (comps != null)
+			{
+				// include wrapped meta_mesh_component (e.g., cloth_simulator/meta_mesh_component)
+				foreach (XElement mm in comps.Descendants("meta_mesh_component"))
+				{
+					string metaName = (string)mm.Attribute("name") ?? string.Empty;
+
+					foreach (XElement meshNode in mm.Elements("mesh"))
+					{
+						XAttribute arg2Attr = meshNode.Attribute("argument2");
+						if (arg2Attr == null) continue;
+
+						if (TryParseVec3(arg2Attr.Value, out Vec3 v))
+						{
+							outEntries.Add(new PrefabArg2
+							{
+								Path = IndicesToPath(indices),
+								MetaMeshName = metaName,
+								MeshName = (string)meshNode.Attribute("name") ?? string.Empty,
+								MaterialName = (string)meshNode.Attribute("material") ?? string.Empty,
+								Arg2 = new Vec3(v.X, v.Y, v.Z, v.w)
+							});
+						}
+					}
+				}
+			}
+
+			XElement children = ge.Element("children");
+			if (children == null) return;
+
+			int idx = 0;
+			foreach (XElement childGE in children.Elements("game_entity"))
+			{
+				indices.Add(idx++);
+				CollectEntityArg2Recursive(childGE, indices, outEntries);
+				indices.RemoveAt(indices.Count - 1);
+			}
+		}
+
+		// ---------- APPLY ----------
+		public static void ApplyArg2Recursive(GameEntity entity, List<PrefabArg2> entries, List<int> indices = null)
+		{
+			indices ??= new List<int>();
+			string path = IndicesToPath(indices);
+
+			for (int i = 0; i < entries.Count; i++)
+			{
+				PrefabArg2 e = entries[i];
+				if (!path.Equals(e.Path, StringComparison.Ordinal)) continue;
+				TryApplyToEntity(entity, e);
+			}
+
+			List<GameEntity> children = entity.GetChildren()?.ToList() ?? new List<GameEntity>();
+			for (int i = 0; i < children.Count; i++)
+			{
+				indices.Add(i);
+				ApplyArg2Recursive(children[i], entries, indices);
+				indices.RemoveAt(indices.Count - 1);
+			}
+		}
+
+		private static void TryApplyToEntity(GameEntity entity, PrefabArg2 entry)
+		{
+			try
+			{
+				for (int i = 0; ; i++)
+				{
+					MetaMesh mm = entity.GetMetaMesh(i);
+					mm ??= entity.GetClothSimulator(i)?.GetFirstMetaMesh();
+					if (mm == null) break;
+
+					if (!string.IsNullOrEmpty(entry.MetaMeshName) && mm.GetName() != entry.MetaMeshName)
+						continue;
+
+					Vec3 cur = mm.GetVectorArgument2();
+					if (IsVec3FullyEqual(entry.Arg2, cur)) continue;
+
+					mm.SetVectorArgument2(entry.Arg2.X, entry.Arg2.Y, entry.Arg2.Z, entry.Arg2.w);
+					Log($"Fixed {entity.Name}/{entry.MetaMeshName} VectorArgument2 to ({entry.Arg2.X},{entry.Arg2.Y},{entry.Arg2.Z},{entry.Arg2.w})");
+				}
+			}
+			catch (Exception ex)
+			{
+				Log($"[PrefabArg2] Apply failed on '{entity?.Name}' at path '{entry.Path}': {ex.Message}", LogLevel.Warning);
+			}
+		}
+
+		// Custom comparison because native ignores w value
+		private static bool IsVec3FullyEqual(Vec3 vecA, Vec3 vecB)
+		{
+			return vecA == vecB && vecA.w == vecB.w;
+		}
+
+		// ---------- SAVE (to copy in PrefabsWithFixedArg2) ----------
+		/// <summary>
+		/// Update (or add) argument2 attributes for a specific prefab root in the source XML,
+		/// then save a copy to Module/PrefabsWithFixedArg2/&lt;same file name&gt;.xml.
+		/// Returns (updated, added, outPath).
+		/// </summary>
+		public static (int updated, int added, string outPath) UpdatePrefabFile(string sourceXmlPath, string prefabName, List<PrefabArg2> entries)
+		{
+			XDocument doc = XDocument.Load(sourceXmlPath);
+			XElement root = doc.Root ?? throw new InvalidOperationException("Invalid prefab XML: missing root.");
+
+			XElement prefabRoot = root.Elements("game_entity")
+				.FirstOrDefault(ge => string.Equals((string)ge.Attribute("name"), prefabName, StringComparison.Ordinal));
+			if (prefabRoot == null)
+				throw new InvalidOperationException($"Prefab '{prefabName}' not found in '{sourceXmlPath}'.");
+
+			int updated = 0, added = 0;
+
+			for (int i = 0; i < entries.Count; i++)
+			{
+				PrefabArg2 e = entries[i];
+				XElement geNode = ResolveGameEntityByPath(prefabRoot, e.Path);
+				if (geNode == null) continue;
+
+				IEnumerable<XElement> metaMeshNodes = geNode.Element("components")?.Descendants("meta_mesh_component")
+					?? Enumerable.Empty<XElement>();
+
+				if (!string.IsNullOrEmpty(e.MetaMeshName))
+					metaMeshNodes = metaMeshNodes.Where(mm => string.Equals((string)mm.Attribute("name"), e.MetaMeshName, StringComparison.Ordinal));
+
+				foreach (XElement mm in metaMeshNodes)
+				{
+					foreach (XElement mesh in mm.Elements("mesh"))
+					{
+						string newVal = FormatVec(e.Arg2);
+						XAttribute a2 = mesh.Attribute("argument2");
+						if (a2 == null)
+						{
+							mesh.Add(new XAttribute("argument2", newVal));
+							added++;
+						}
+						else if (!string.Equals(a2.Value, newVal, StringComparison.Ordinal))
+						{
+							a2.Value = newVal;
+							updated++;
+						}
+					}
+				}
+			}
+
+			// Write to copy: Module/PrefabsWithFixedArg2/<same file name>.xml
+			string modulePath = ModuleHelper.GetModuleFullPath(SubModule.CurrentModuleName);
+			string outDir = Path.Combine(modulePath, "PrefabsWithFixedArg2");
+			Directory.CreateDirectory(outDir);
+			string outPath = Path.Combine(outDir, Path.GetFileName(sourceXmlPath));
+
+			AtomicWrite(doc, outPath);
+			return (updated, added, outPath);
+		}
+
+		// ---------- Helpers ----------
+		public static List<PrefabArg2> CollectRuntimeArg2(GameEntity root)
+		{
+			var result = new List<PrefabArg2>();
+			void DFS(GameEntity node, List<int> idx)
+			{
+				string path = IndicesToPath(idx);
+
+				for (int i = 0; ; i++)
+				{
+					MetaMesh mm = node.GetMetaMesh(i);
+					mm ??= node.GetClothSimulator(i)?.GetFirstMetaMesh();
+					if (mm == null) break;
+
+					Vec3 v = mm.GetVectorArgument2();
+					string metaName = mm.GetName();
+
+					result.Add(new PrefabArg2
+					{
+						Path = path,
+						MetaMeshName = metaName,
+						MeshName = string.Empty,
+						MaterialName = string.Empty,
+						Arg2 = v
+					});
+				}
+
+				List<GameEntity> children = node.GetChildren()?.ToList() ?? new List<GameEntity>();
+				for (int c = 0; c < children.Count; c++)
+				{
+					idx.Add(c);
+					DFS(children[c], idx);
+					idx.RemoveAt(idx.Count - 1);
+				}
+			}
+
+			DFS(root, new List<int>());
+			return result;
+		}
+
+		/// Find an XML file containing a root <game_entity name="prefabName"> under a directory (recursive).
+		public static string TryFindPrefabXml(string rootDir, string prefabName)
+		{
+			if (!Directory.Exists(rootDir)) return null;
+
+			foreach (string file in Directory.EnumerateFiles(rootDir, "*.xml", SearchOption.AllDirectories))
+			{
+				try
+				{
+					XDocument doc = XDocument.Load(file);
+					XElement root = doc.Root;
+					if (root == null) continue;
+
+					if (root.Elements("game_entity").Any(ge => string.Equals((string)ge.Attribute("name"), prefabName, StringComparison.Ordinal)))
+						return file;
+				}
+				catch { /* ignore unreadable files */ }
+			}
+			return null;
+		}
+
+		private static XElement ResolveGameEntityByPath(XElement prefabRoot, string path)
+		{
+			if (string.IsNullOrEmpty(path) || path == "/") return prefabRoot;
+
+			XElement cur = prefabRoot;
+			string[] parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+			for (int i = 0; i < parts.Length; i++)
+			{
+				if (!int.TryParse(parts[i], out int idx)) return null;
+				XElement children = cur.Element("children");
+				if (children == null) return null;
+				XElement child = children.Elements("game_entity").ElementAtOrDefault(idx);
+				if (child == null) return null;
+				cur = child;
+			}
+			return cur;
+		}
+
+		private static string IndicesToPath(List<int> idx)
+		{
+			if (idx == null || idx.Count == 0) return "/";
+			StringBuilder sb = new StringBuilder(2 * idx.Count + 1);
+			sb.Append('/');
+			for (int i = 0; i < idx.Count; i++)
+			{
+				if (i > 0) sb.Append('/');
+				sb.Append(idx[i]);
+			}
+			return sb.ToString();
+		}
+
+		private static bool TryParseVec3(string s, out Vec3 v)
+		{
+			v = default;
+			if (string.IsNullOrWhiteSpace(s)) return false;
+			string[] parts = s.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+			if (parts.Length != 4) return false;
+			if (!float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float x)) return false;
+			if (!float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float y)) return false;
+			if (!float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float z)) return false;
+			if (!float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float w)) return false;
+			v = new Vec3(x, y, z, w);
+			return true;
+		}
+
+		private static string FormatVec(Vec3 v) =>
+			string.Format(CultureInfo.InvariantCulture, "{0:0.000}, {1:0.000}, {2:0.000}, {3:0.000}", v.X, v.Y, v.Z, v.w);
+
+		private static void AtomicWrite(XDocument doc, string path)
+		{
+			Encoding enc = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+			var settings = new XmlWriterSettings
+			{
+				Indent = true,
+				IndentChars = "\t",
+				NewLineChars = "\n",
+				NewLineHandling = NewLineHandling.Replace,
+				OmitXmlDeclaration = true,
+				Encoding = enc
+			};
+
+			string tmp = path + ".tmp";
+			using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None, 64 * 1024, FileOptions.WriteThrough))
+			using (var xw = XmlWriter.Create(fs, settings))
+			{
+				doc.Save(xw);
+				xw.Flush();
+				fs.Flush(true);
+			}
+			Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+			if (File.Exists(path)) File.Replace(tmp, path, null, true);
+			else File.Move(tmp, path);
+		}
+	}
+
+	public class PrefabArg2
+	{
+		public string Path;          // "/0/1/..."
+		public string MetaMeshName;  // <meta_mesh_component name="...">
+		public string MeshName;      // <mesh name="...">
+		public string MaterialName;  // <mesh material="...">
+		public Vec3 Arg2;          // (x,y,z,w) via your Vec3 with .w
+	}
+}

--- a/Alliance.Common/Extensions/CustomScripts/Scripts/CS_EditorFixer.cs
+++ b/Alliance.Common/Extensions/CustomScripts/Scripts/CS_EditorFixer.cs
@@ -348,20 +348,40 @@ namespace Alliance.Common.Extensions.CustomScripts.Scripts
 		/// </summary>
 		public static (int updated, int added, string outPath) UpdatePrefabFile(string sourceXmlPath, string prefabName, List<PrefabArg2> entries)
 		{
-			XDocument doc = XDocument.Load(sourceXmlPath);
-			XElement root = doc.Root ?? throw new InvalidOperationException("Invalid prefab XML: missing root.");
+			// Paths
+			string modulePath = ModuleHelper.GetModuleFullPath(SubModule.CurrentModuleName);
+			string outDir = Path.Combine(modulePath, "PrefabsWithFixedArg2");
+			Directory.CreateDirectory(outDir);
+			string outPath = Path.Combine(outDir, Path.GetFileName(sourceXmlPath));
 
-			XElement prefabRoot = root.Elements("game_entity")
+			// 1) Load NATIVE doc and grab the target prefab (baseline structure)
+			XDocument nativeDoc = XDocument.Load(sourceXmlPath);
+			XElement nativeRoot = nativeDoc.Root ?? throw new InvalidOperationException("Invalid prefab XML: missing root.");
+			XElement nativePrefab = nativeRoot.Elements("game_entity")
+				.FirstOrDefault(ge => string.Equals((string)ge.Attribute("name"), prefabName, StringComparison.Ordinal))
+				?? throw new InvalidOperationException($"Prefab '{prefabName}' not found in '{sourceXmlPath}'.");
+
+			// 2) Load WORKING doc (override if exists, otherwise start from native)
+			XDocument workDoc = File.Exists(outPath) ? XDocument.Load(outPath) : new XDocument(new XElement(nativeRoot));
+			XElement workRoot = workDoc.Root ?? throw new InvalidOperationException("Invalid prefab XML: missing root.");
+
+			// 3) Replace ONLY the target prefab in the working doc with the fresh native one
+			XElement workPrefab = workRoot.Elements("game_entity")
 				.FirstOrDefault(ge => string.Equals((string)ge.Attribute("name"), prefabName, StringComparison.Ordinal));
-			if (prefabRoot == null)
-				throw new InvalidOperationException($"Prefab '{prefabName}' not found in '{sourceXmlPath}'.");
 
+			XElement nativeClone = new XElement(nativePrefab); // deep clone
+
+			if (workPrefab != null)
+				workPrefab.ReplaceWith(nativeClone);
+			else
+				workRoot.Add(nativeClone);
+
+			// 4) Apply/merge argument2 updates onto the (now native) prefab element
 			int updated = 0, added = 0;
 
-			for (int i = 0; i < entries.Count; i++)
+			foreach (var e in entries)
 			{
-				PrefabArg2 e = entries[i];
-				XElement geNode = ResolveGameEntityByPath(prefabRoot, e.Path);
+				XElement geNode = ResolveGameEntityByPath(nativeClone, e.Path);
 				if (geNode == null) continue;
 
 				IEnumerable<XElement> metaMeshNodes = geNode.Element("components")?.Descendants("meta_mesh_component")
@@ -390,13 +410,8 @@ namespace Alliance.Common.Extensions.CustomScripts.Scripts
 				}
 			}
 
-			// Write to copy: Module/PrefabsWithFixedArg2/<same file name>.xml
-			string modulePath = ModuleHelper.GetModuleFullPath(SubModule.CurrentModuleName);
-			string outDir = Path.Combine(modulePath, "PrefabsWithFixedArg2");
-			Directory.CreateDirectory(outDir);
-			string outPath = Path.Combine(outDir, Path.GetFileName(sourceXmlPath));
-
-			AtomicWrite(doc, outPath);
+			// 5) Write back atomically to the override file (other prefabs remain untouched)
+			AtomicWrite(workDoc, outPath);
 			return (updated, added, outPath);
 		}
 

--- a/Alliance.Common/Extensions/CustomScripts/Scripts/CS_TextPanel.cs
+++ b/Alliance.Common/Extensions/CustomScripts/Scripts/CS_TextPanel.cs
@@ -1,0 +1,121 @@
+﻿using Alliance.Common.Core.Utils;
+using System.Linq;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Core.Utils.EntityUtils;
+using static Alliance.Common.Utilities.Logger;
+using Material = TaleWorlds.Engine.Material;
+
+namespace Alliance.Common.Extensions.CustomScripts.Scripts
+{
+	/// <summary>
+	/// Display custom text on an object. 
+	/// TODO: Can be synchronized.
+	/// TODO: Can optionally be edited by players.
+	/// Generates ONE mesh (two triangles per glyph) on the XZ plane.
+	/// </summary>
+	public class CS_TextPanel : SynchedMissionObject, IFocusable
+	{
+		public string Text = "Hello world";
+		public bool IsSynchronized = true;
+		public bool IsEditable = false;
+		public float FontSize = 0.5f; // meters (glyph height)
+		public float LetterSpacing = 0f; // in "em" relative to glyph width; e.g., 0.1 = +10%
+		public float LineSpacing = 1f; // multiplier for space beween lines;
+		public float PanelMaxWidth = 4f; // meters; <=0 = no wrap
+		public TextHorizontalAlignment TextAlignment = TextHorizontalAlignment.Center;
+		public AvailableFonts Font = AvailableFonts.Galahad;
+
+		public SimpleButton RENDER;
+
+		public FocusableObjectType FocusableObjectType => FocusableObjectType.None;
+
+		protected override void OnEditorVariableChanged(string variableName)
+		{
+			if (variableName == nameof(RENDER) ||
+				variableName == nameof(Text) ||
+				variableName == nameof(FontSize) ||
+				variableName == nameof(PanelMaxWidth) ||
+				variableName == nameof(TextAlignment) ||
+				variableName == nameof(Font) ||
+				variableName == nameof(LetterSpacing) ||
+				variableName == nameof(LineSpacing))
+			{
+				Render();
+			}
+		}
+
+		public string ResolveMaterialName()
+		{
+			string materialName = Font.ToString().ToLower();
+			if (Material.GetFromResource(materialName) == null)
+			{
+				Log($"[CS_TextPanel] Material '{materialName}' not found, using default.", LogLevel.Warning);
+				materialName = Material.GetDefaultMaterial().Name;
+			}
+			return materialName;
+		}
+
+		public void Render()
+		{
+			EntityUtils.EnqueueTextPanel(this);
+		}
+
+		protected override void OnEditorTick(float dt)
+		{
+			base.OnEditorTick(dt);
+		}
+
+		protected override void OnInit()
+		{
+			base.OnInit();
+			EntityUtils.EnqueueTextPanel(this);
+		}
+
+		protected override void OnEditorInit()
+		{
+			base.OnEditorInit();
+			EntityUtils.EnqueueTextPanel(this);
+		}
+
+		public void OnFocusGain(Agent userAgent)
+		{
+		}
+
+		public void OnFocusLose(Agent userAgent)
+		{
+		}
+
+		public TextObject GetInfoTextForBeingNotInteractable(Agent userAgent)
+		{
+			return new TextObject();
+		}
+
+		public string GetDescriptionText(GameEntity gameEntity = null)
+		{
+			if (int.TryParse(gameEntity.Name.Split(new char[] { '_' }).Last(), out int num))
+			{
+				string text = gameEntity.Name;
+				text = text.Remove(text.Count() - num.ToString().Count());
+				text += "x";
+				TextObject textObject;
+				if (GameTexts.TryGetText("str_destructible_component", out textObject, text))
+				{
+					return textObject.ToString();
+				}
+				return "";
+			}
+			else
+			{
+				TextObject textObject2;
+				if (GameTexts.TryGetText("str_destructible_component", out textObject2, gameEntity.Name))
+				{
+					return textObject2.ToString();
+				}
+				return "";
+			}
+		}
+	}
+}

--- a/Alliance.Editor/SubModule.cs
+++ b/Alliance.Editor/SubModule.cs
@@ -108,6 +108,7 @@ namespace Alliance.Editor
 
 		protected override void OnApplicationTick(float dt)
 		{
+			EntityUtils.Tick(dt);
 			EditorToolsManager.EditorTools.Tick(dt);
 			if (Input.IsKeyPressed(InputKey.O))
 			{

--- a/Alliance.Editor/_Module/SubModule.xml
+++ b/Alliance.Editor/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance.Editor" />
   <Name value="Alliance.Editor" />
-  <Version value="v0.4.7.0" />
+  <Version value="v0.4.8.0" />
   <ModuleCategory value="Singleplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.SP/_Module/SubModule.xml
+++ b/Alliance.SP/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance.SP" />
   <Name value="Alliance.SP" />
-  <Version value="v0.4.7.0" />
+  <Version value="v0.4.8.0" />
   <ModuleCategory value="Singleplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.Server/_Module/SubModule.xml
+++ b/Alliance.Server/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance" />
   <Name value="Alliance" />
-  <Version value="v0.4.7.0" />
+  <Version value="v0.4.8.0" />
   <ModuleCategory value="Multiplayer" />
   <DependedModules>
     <DependedModule Id="Native" />


### PR DESCRIPTION
New scripts for mapmaking : 
- CS_TextPanel : Generate a plane mesh displaying a custom text. 3 different fonts are available, and font size/letter spacing/line spacing/max width can be customized. TODO : add synchronization and allow players to edit them in-game (optional)

- CS_Array :  Similar to Blender "Array" modifier. It can duplicate objects, apply relative/constant offsets, use optional object offset. It can also assign dynamic tags to the duplicated entities.

- CS_EditorFixer : Attempt to fix some Modding Kit issues. Natively, vector arguments 2 (used by some shaders for scaling materials for example) are not applied/saved properly to prefabs. The script allow applying the correct arguments to all entities in the scene with a single click. It also allow saving the prefab with the correct arguments.  And it can autobreak prefabs so they are saved properly to the scene file.

- CS_DynamicPile : Raises cones with volume, spins + heartbeat, and simulates a texture sweep by driving VectorArgument2.Z (0..1) synchronized to the heartbeat.