### PR TITLE
Alliance v0.5.7.0 - PvC - UI - Fixes

### DIFF
--- a/Alliance.Client/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -28,14 +28,13 @@ namespace Alliance.Client.Extensions.TroopSpawner.Handlers
 		public void HandleFormationControlMessage(FormationControlMessage message)
 		{
 			MissionPeer target = message.Peer.GetComponent<MissionPeer>();
-			Team team = Mission.MissionNetworkHelper.GetTeamFromTeamIndex(message.TeamIndex);
 			if (message.Delete)
 			{
-				FormationControlModel.Instance.RemoveControlFromPlayer(target, team, message.Formation);
+				FormationControlModel.Instance.RemoveControlFromPlayer(target, message.TeamIndex, message.Formation);
 			}
 			else
 			{
-				FormationControlModel.Instance.AssignControlToPlayer(target, team, message.Formation);
+				FormationControlModel.Instance.AssignControlToPlayer(target, message.TeamIndex, message.Formation);
 			}
 		}
 

--- a/Alliance.Client/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -28,13 +28,14 @@ namespace Alliance.Client.Extensions.TroopSpawner.Handlers
 		public void HandleFormationControlMessage(FormationControlMessage message)
 		{
 			MissionPeer target = message.Peer.GetComponent<MissionPeer>();
+			Team team = Mission.MissionNetworkHelper.GetTeamFromTeamIndex(message.TeamIndex);
 			if (message.Delete)
 			{
-				FormationControlModel.Instance.RemoveControlFromPlayer(target, message.Formation);
+				FormationControlModel.Instance.RemoveControlFromPlayer(target, team, message.Formation);
 			}
 			else
 			{
-				FormationControlModel.Instance.AssignControlToPlayer(target, message.Formation);
+				FormationControlModel.Instance.AssignControlToPlayer(target, team, message.Formation);
 			}
 		}
 

--- a/Alliance.Client/Extensions/TroopSpawner/ViewModels/FormationVM.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/ViewModels/FormationVM.cs
@@ -92,17 +92,15 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 		public FormationVM(Formation formation, Action<FormationVM> selectFormation)
 		{
 			Formation = formation;
-			RefreshCommanderInfos();
-			FormationControlModel.Instance.FormationControlChanged += RefreshCommanderInfos;
 			OrderTroopVM = new OrderTroopItemVM(formation, null, new Func<Formation, int>(GetFormationMorale));
 			OrderTroopVM.IsSelectable = true;
 			Formation.OnUnitCountChanged += RefreshFormationInfos;
 			_onFormationSelected = selectFormation;
+			SetCommanderInfos(FormationControlModel.Instance.GetControllerOfFormation(Formation));
 		}
 
 		public override void OnFinalize()
 		{
-			FormationControlModel.Instance.FormationControlChanged -= RefreshCommanderInfos;
 			Formation.OnUnitCountChanged -= RefreshFormationInfos;
 		}
 
@@ -113,12 +111,14 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 
 		public void RefreshCommanderVisual(Agent agent)
 		{
-			if (agent != null && OrderTroopVM != null) OrderTroopVM.CaptainImageIdentifier = new CharacterImageIdentifierVM(CharacterCode.CreateFrom(agent.Character));
+			if (OrderTroopVM == null) return;
+
+			if (agent != null) OrderTroopVM.CaptainImageIdentifier = new CharacterImageIdentifierVM(CharacterCode.CreateFrom(agent.Character));
+			else OrderTroopVM.CaptainImageIdentifier = null;
 		}
 
-		private void RefreshCommanderInfos()
+		public void SetCommanderInfos(MissionPeer commander)
 		{
-			MissionPeer commander = FormationControlModel.Instance.GetControllerOfFormation(Formation);
 			HasCommander = commander != null;
 			CommanderName = commander?.Name;
 			RefreshCommanderVisual(commander?.ControlledAgent);

--- a/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
@@ -334,23 +334,16 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 			Difficulty = SpawnHelper.DifficultyLevelFromString(Config.Instance.BotDifficulty);
 			UseTroopCost = Config.Instance.UseTroopCost;
 
-			Formations = new MBBindingList<FormationVM>();
-			for (int i = 0; i < 8; i++)
-			{
-				Formation formation = SpawnTroopsModel.Instance.SelectedTeam?.GetFormation((FormationClass)i);
-				FormationVM formationVM = new FormationVM(formation, SelectFormation);
-				if (i == SpawnTroopsModel.Instance.FormationSelected)
-				{
-					_selectedFormation = formationVM;
-					_selectedFormation.Selected = true;
-				}
-				Formations.Add(formationVM);
-				formationVM.Formation.OnUnitAdded += RefreshCommanderVisual;
-			}
+			MissionPeer myPeer = GameNetwork.MyPeer?.GetComponent<MissionPeer>();
+			SpawnTroopsModel.Instance.SelectedTeam = myPeer?.Team;
+			RefreshFormations();
+
 			SpawnTroopsModel.Instance.OnDifficultyUpdated += RefreshGold;
 			SpawnTroopsModel.Instance.OnTroopSelected += RefreshGold;
 			SpawnTroopsModel.Instance.OnTroopCountUpdated += RefreshGold;
 			SpawnTroopsModel.Instance.OnFactionSelected += RefreshFormations;
+			SpawnTroopsModel.Instance.OnFormationUpdated += RefreshFormations;
+			FormationControlModel.Instance.FormationControlChanged += OnFormationControlChanged;
 			_myRepresentative.OnGoldUpdated += RefreshGold;
 
 			TroopGroupVM troopGroupVM = TroopList.TroopGroups.FirstOrDefault();
@@ -361,13 +354,14 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 
 		public override void OnFinalize()
 		{
-			foreach (FormationVM formationVM in Formations)
-			{
-				formationVM.Formation.OnUnitAdded -= RefreshCommanderVisual;
-			}
+			foreach (FormationVM formationVM in Formations) formationVM.OnFinalize();
 			SpawnTroopsModel.Instance.OnDifficultyUpdated -= RefreshGold;
 			SpawnTroopsModel.Instance.OnTroopSelected -= RefreshGold;
 			SpawnTroopsModel.Instance.OnTroopCountUpdated -= RefreshGold;
+			SpawnTroopsModel.Instance.OnFactionSelected -= RefreshFormations;
+			SpawnTroopsModel.Instance.OnFormationUpdated -= RefreshFormations;
+			FormationControlModel.Instance.FormationControlChanged -= OnFormationControlChanged;
+			_myRepresentative.OnGoldUpdated -= RefreshGold;
 		}
 
 		public override void RefreshValues()
@@ -375,6 +369,7 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 			// Refresh selected team
 			MissionPeer myPeer = GameNetwork.MyPeer?.GetComponent<MissionPeer>();
 			SpawnTroopsModel.Instance.SelectedTeam = myPeer?.Team;
+			RefreshFormations();
 		}
 
 		private void RefreshGold()
@@ -402,29 +397,21 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 			CanRecruit = GameNetwork.MyPeer.IsAdmin() || GameNetwork.MyPeer.IsCommander() && !troopTooCostly;
 		}
 
-		private void RefreshCommanderVisual(Formation formation, Agent agent)
+		private void OnFormationControlChanged(FormationClass formationClass, Team team, MissionPeer commander)
 		{
-			if (formation.Captain == null && agent.MissionPeer != null)
+			if (Formations == null || Formations.Count < (int)formationClass || SpawnTroopsModel.Instance.SelectedTeam != team)
 			{
-				// If new agent is the commander
-				if (FormationControlModel.Instance.GetControllerOfFormation(formation) == agent.MissionPeer)
-				{
-					// Update the commander visual in all of his formations
-					List<FormationClass> formationToRefresh = FormationControlModel.Instance.GetControlledFormations(agent.MissionPeer);
-					foreach (FormationClass formationClass in formationToRefresh)
-					{
-						Formations[(int)formationClass].RefreshCommanderVisual(agent);
-						Log("Updating commander visual for formation " + (int)formationClass, LogLevel.Debug);
-					}
-				}
+				return;
 			}
+
+			Formations[(int)formationClass].SetCommanderInfos(commander);
 		}
 
 		private void RefreshFormations()
 		{
-			foreach (FormationVM formationVM in Formations)
+			if(Formations != null)
 			{
-				formationVM.Formation.OnUnitAdded -= RefreshCommanderVisual;
+				foreach (FormationVM formationVM in Formations) formationVM.OnFinalize();
 			}
 			Formations = new MBBindingList<FormationVM>();
 			for (int i = 0; i < 8; i++)
@@ -437,7 +424,6 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 					_selectedFormation.Selected = true;
 				}
 				Formations.Add(formationVM);
-				formationVM.Formation.OnUnitAdded += RefreshCommanderVisual;
 			}
 		}
 

--- a/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
@@ -394,7 +394,7 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 				TotalGold = totalGold;
 			}
 
-			CanRecruit = GameNetwork.MyPeer.IsAdmin() || GameNetwork.MyPeer.IsCommander() && !troopTooCostly;
+			CanRecruit = (GameNetwork.MyPeer.IsAdmin() || GameNetwork.MyPeer.IsCommander()) && !troopTooCostly;
 		}
 
 		private void OnFormationControlChanged(int teamIndex, FormationClass formationClass, MissionPeer commander)

--- a/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
+++ b/Alliance.Client/Extensions/TroopSpawner/ViewModels/TroopSpawnMenuVM.cs
@@ -397,9 +397,9 @@ namespace Alliance.Client.Extensions.TroopSpawner.ViewModels
 			CanRecruit = GameNetwork.MyPeer.IsAdmin() || GameNetwork.MyPeer.IsCommander() && !troopTooCostly;
 		}
 
-		private void OnFormationControlChanged(FormationClass formationClass, Team team, MissionPeer commander)
+		private void OnFormationControlChanged(int teamIndex, FormationClass formationClass, MissionPeer commander)
 		{
-			if (Formations == null || Formations.Count < (int)formationClass || SpawnTroopsModel.Instance.SelectedTeam != team)
+			if (Formations == null || Formations.Count < (int)formationClass || SpawnTroopsModel.Instance.SelectedTeam.TeamIndex != teamIndex)
 			{
 				return;
 			}

--- a/Alliance.Client/GameModes/PvC/PvCGameMode.cs
+++ b/Alliance.Client/GameModes/PvC/PvCGameMode.cs
@@ -30,6 +30,7 @@ namespace Alliance.Client.GameModes.PvC
 
 				// Native behaviors
 				new MultiplayerRoundComponent(),
+				new MultiplayerWarmupComponent(),
 				new MultiplayerTeamSelectComponent()
 			});
 			return behaviors;

--- a/Alliance.Client/Patch/HarmonyPatch/Patch_MPLobby.cs
+++ b/Alliance.Client/Patch/HarmonyPatch/Patch_MPLobby.cs
@@ -32,7 +32,18 @@ namespace Alliance.Client.Patch.HarmonyPatch
 			"act_arena_spectator",
 			"act_childhood_toddler_vigor",
 			"act_childhood_toddler_endurance",
-			"act_childhood_toddler_social"
+			"act_childhood_toddler_social",
+			"act_main_story_conspirator_kneel_down_1_continue",
+			"act_main_story_conspirator_kneel_down_2_continue",
+			"act_main_story_conspirator_kneel_down_3_continue",
+			"act_cutscene_kingdom_made_pose_02",
+			"act_cutscene_kingdom_made_pose_04",
+			"act_cutscene_kingdom_made_pose_05",
+			"act_cutscene_kingdom_made_pose_06",
+			"act_cutscene_join_faction_crew_d_loop",
+			"act_character_creation_nord_shipwrights_father",
+			"act_character_creation_nord_shipwrights_mother",
+			"act_talk_to_1"
 		};
 
 		private static readonly Harmony Harmony = new Harmony(SubModule.ModuleId + nameof(Patch_MPLobby));

--- a/Alliance.Client/_Module/GUI/Prefabs/Lobby/Armory/Lobby.Armory.xml
+++ b/Alliance.Client/_Module/GUI/Prefabs/Lobby/Armory/Lobby.Armory.xml
@@ -1,318 +1,338 @@
 <Prefab>
-  <Constants>
-    <Constant Name="TopHeader.Height" BrushLayer="Default" BrushName="MPLobby.TopHeader.Background" BrushValueType="Height" />
+	<Constants>
+		<Constant Name="TopHeader.Height" BrushLayer="Default" BrushName="MPLobby.TopHeader.Background" BrushValueType="Height" />
 
-    <Constant Name="SkinCategoryButton.Width" BrushLayer="Default" BrushName="MPLobby.Armory.Skins.CategoryButton" BrushValueType="Width" />
-    <Constant Name="SkinCategoryButton.Height" BrushLayer="Default" BrushName="MPLobby.Armory.Skins.CategoryButton" BrushValueType="Height" />
+		<Constant Name="SkinCategoryButton.Width" BrushLayer="Default" BrushName="MPLobby.Armory.Skins.CategoryButton" BrushValueType="Width" />
+		<Constant Name="SkinCategoryButton.Height" BrushLayer="Default" BrushName="MPLobby.Armory.Skins.CategoryButton" BrushValueType="Height" />
 
-    <Constant Name="ItemBackground.Width" BrushLayer="Default" BrushName="MPLobby.ItemBackground" BrushValueType="Width" />
-    <Constant Name="ItemBackground.Height" BrushLayer="Default" BrushName="MPLobby.ItemBackground" BrushValueType="Height" />
+		<Constant Name="ItemBackground.Width" BrushLayer="Default" BrushName="MPLobby.ItemBackground" BrushValueType="Width" />
+		<Constant Name="ItemBackground.Height" BrushLayer="Default" BrushName="MPLobby.ItemBackground" BrushValueType="Height" />
 
-    <Constant Name="CustomizeButton.Width" BrushLayer="Default" BrushName="WideButton.Flat" BrushValueType="Width" />
-    <Constant Name="CustomizeButton.Height" BrushLayer="Default" BrushName="WideButton.Flat" BrushValueType="Height" />
+		<Constant Name="CustomizeButton.Width" BrushLayer="Default" BrushName="WideButton.Flat" BrushValueType="Width" />
+		<Constant Name="CustomizeButton.Height" BrushLayer="Default" BrushName="WideButton.Flat" BrushValueType="Height" />
 
-    <Constant Name="Perks.Background.Width" BrushLayer="Default" BrushName="MPLobby.Perks.Background" BrushValueType="Width" />
-    <Constant Name="Perks.Background.Height" Additive="-12" BrushLayer="Default" BrushName="MPLobby.Perks.Background" BrushValueType="Height" />
+		<Constant Name="Perks.Background.Width" BrushLayer="Default" BrushName="MPLobby.Perks.Background" BrushValueType="Width" />
+		<Constant Name="Perks.Background.Height" Additive="-12" BrushLayer="Default" BrushName="MPLobby.Perks.Background" BrushValueType="Height" />
 
-    <Constant Name="DropdownHeader.Width" BrushName="MPLobby.Matchmaking.Region.DropdownHeader" BrushLayer="Default" BrushValueType="Width"/>
-    <Constant Name="DropdownHeader.Height" BrushName="MPLobby.Matchmaking.Region.DropdownHeader" BrushLayer="Default" BrushValueType="Height"/>
+		<Constant Name="DropdownHeader.Width" BrushName="MPLobby.Matchmaking.Region.DropdownHeader" BrushLayer="Default" BrushValueType="Width"/>
+		<Constant Name="DropdownHeader.Height" BrushName="MPLobby.Matchmaking.Region.DropdownHeader" BrushLayer="Default" BrushValueType="Height"/>
 
-    <Constant Name="Taunt.Enabled.Radial.Distance" Value="170" />
-    <Constant Name="Taunt.Disabled.Radial.Distance" Value="100" />
-  </Constants>
-  <VisualDefinitions>
-    <VisualDefinition Name="LeftSideVisuals" TransitionDuration="0.27">
-      <VisualState State="Default" PositionXOffset="0" />
-      <VisualState State="TauntEnabled" PositionXOffset="-750" />
-    </VisualDefinition>
+		<Constant Name="Taunt.Enabled.Radial.Distance" Value="170" />
+		<Constant Name="Taunt.Disabled.Radial.Distance" Value="100" />
+	</Constants>
+	<VisualDefinitions>
+		<VisualDefinition Name="LeftSideVisuals" TransitionDuration="0.27">
+			<VisualState State="Default" PositionXOffset="0" />
+			<VisualState State="TauntEnabled" PositionXOffset="-750" />
+		</VisualDefinition>
 
-    <VisualDefinition Name="LeftSideDropdownVisuals" TransitionDuration="0.27">
-      <VisualState State="Default" PositionXOffset="0" />
-      <VisualState State="TauntEnabled" PositionXOffset="-750" />
-    </VisualDefinition>
+		<VisualDefinition Name="LeftSideDropdownVisuals" TransitionDuration="0.27">
+			<VisualState State="Default" PositionXOffset="0" />
+			<VisualState State="TauntEnabled" PositionXOffset="-750" />
+		</VisualDefinition>
 
-    <VisualDefinition Name="TauntRadialCircle" TransitionDuration="0.27">
-      <VisualState State="Default" SuggestedHeight="105" SuggestedWidth="105" />
-      <VisualState State="TauntEnabled" SuggestedHeight="170" SuggestedWidth="170" />
-    </VisualDefinition>
+		<VisualDefinition Name="TauntRadialCircle" TransitionDuration="0.27">
+			<VisualState State="Default" SuggestedHeight="105" SuggestedWidth="105" />
+			<VisualState State="TauntEnabled" SuggestedHeight="170" SuggestedWidth="170" />
+		</VisualDefinition>
 
-    <VisualDefinition Name="TauntSlotsContainer" TransitionDuration="0.27">
-      <VisualState State="Default" PositionXOffset="0" PositionYOffset="0" />
-      <VisualState State="TauntEnabled" PositionXOffset="-250" PositionYOffset="125" />
-    </VisualDefinition>
-    
-    <VisualDefinition Name="TauntIcon" TransitionDuration="0.27">
-      <VisualState State="Default" SuggestedWidth="50" SuggestedHeight="50" />
-      <VisualState State="TauntEnabled" SuggestedWidth="82" SuggestedHeight="82" />
-    </VisualDefinition>
+		<VisualDefinition Name="TauntSlotsContainer" TransitionDuration="0.27">
+			<VisualState State="Default" PositionXOffset="0" PositionYOffset="0" />
+			<VisualState State="TauntEnabled" PositionXOffset="-250" PositionYOffset="125" />
+		</VisualDefinition>
 
-    <VisualDefinition Name="RadialTextAlpha" TransitionDuration="0.27">
-      <VisualState State="Default" AlphaFactor="0"/>
-      <VisualState State="TauntEnabled" AlphaFactor="1"/>
-    </VisualDefinition>
+		<VisualDefinition Name="TauntIcon" TransitionDuration="0.27">
+			<VisualState State="Default" SuggestedWidth="50" SuggestedHeight="50" />
+			<VisualState State="TauntEnabled" SuggestedWidth="82" SuggestedHeight="82" />
+		</VisualDefinition>
 
-    <VisualDefinition Name="ManageTauntsButton" TransitionDuration="0.27">
-      <VisualState State="Default" SuggestedWidth="280" SuggestedHeight="280"/>
-      <VisualState State="TauntEnabled" SuggestedWidth="120" SuggestedHeight="120"/>
-    </VisualDefinition>
+		<VisualDefinition Name="RadialTextAlpha" TransitionDuration="0.27">
+			<VisualState State="Default" AlphaFactor="0"/>
+			<VisualState State="TauntEnabled" AlphaFactor="1"/>
+		</VisualDefinition>
 
-  </VisualDefinitions>
-  <Window>
-    <MultiplayerArmoryPageWidget DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginTop="!TopHeader.Height" IsTauntControlsOpen="@IsManagingTaunts" IsTauntAssignmentActive="@IsTauntAssignmentActive" TauntEnabledRadialDistance="!Taunt.Enabled.Radial.Distance" TauntDisabledRadialDistance="!Taunt.Disabled.Radial.Distance" TauntAssignmentOverlay="TauntAssignmentOverlay" RightPanelTabControl="RightSideParent\RightAreaTabControl" TauntSlotsContainer="TauntSlotsContainer" TauntCircleActionSelector="TauntSlotsContainer\TauntsRadial" LeftSideParent="LeftSideParent" GameModesDropdownParent="GameModesDropdownParent" HeroPreviewParent="HeroPreview" ManageTauntsButton="TauntSlotsContainer\ManageTauntsButton" Command.ReleaseTauntSelections="ExecuteClearTauntSelection" TauntAssignmentOverlayAlpha="0.37" TauntStateAnimationDuration="0.27" >
-      <Children>
+		<VisualDefinition Name="ManageTauntsButton" TransitionDuration="0.27">
+			<VisualState State="Default" SuggestedWidth="280" SuggestedHeight="280"/>
+			<VisualState State="TauntEnabled" SuggestedWidth="120" SuggestedHeight="120"/>
+		</VisualDefinition>
 
-        <!-- Selected Character -->
-        <Widget Id="HeroPreview" DataSource="{HeroPreview}" DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
-          <Children>
+	</VisualDefinitions>
+	<Window>
+		<MultiplayerArmoryPageWidget DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginTop="!TopHeader.Height" IsTauntControlsOpen="@IsManagingTaunts" IsTauntAssignmentActive="@IsTauntAssignmentActive" TauntEnabledRadialDistance="!Taunt.Enabled.Radial.Distance" TauntDisabledRadialDistance="!Taunt.Disabled.Radial.Distance" TauntAssignmentOverlay="TauntAssignmentOverlay" RightPanelTabControl="RightSideParent\RightAreaTabControl" TauntSlotsContainer="TauntSlotsContainer" TauntCircleActionSelector="TauntSlotsContainer\TauntsRadial" LeftSideParent="LeftSideParent" GameModesDropdownParent="GameModesDropdownParent" HeroPreviewParent="HeroPreview" ManageTauntsButton="TauntSlotsContainer\ManageTauntsButton" Command.ReleaseTauntSelections="ExecuteClearTauntSelection" TauntAssignmentOverlayAlpha="0.37" TauntStateAnimationDuration="0.27" >
+			<Children>
 
-            <AL_CharacterTableauWidget DataSource="{HeroVisual}" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="1500" SuggestedHeight="1150" HorizontalAlignment="Center" VerticalAlignment="Bottom" PositionYOffset="-25" BannerCodeText="@BannerCodeText" BodyProperties="@BodyProperties" CharStringId="@CharStringId" EquipmentCode="@EquipmentCode" IsFemale="@IsFemale" MountCreationKey="@MountCreationKey" StanceIndex="@StanceIndex" ArmorColor1="@ArmorColor1" Race="@Race" ArmorColor2="@ArmorColor2" IdleAction="@IdleAction" DoNotUseCustomScale="true" CustomAnimationProgressRatio="@CustomAnimationProgressRatio" IsPlayingCustomAnimations="@IsPlayingCustomAnimations" CustomAnimationWaitDuration="@CustomAnimationWaitDuration" CustomAnimation="@CustomAnimation" SwapPlacesButtonWidget="SwapPlacesButtonWidget" RightHandWieldedEquipmentIndex="@RightHandWieldedEquipmentIndex" LeftHandWieldedEquipmentIndex="@LeftHandWieldedEquipmentIndex">
-              <Children>
-                <ButtonWidget Id="SwapPlacesButtonWidget" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="50" SuggestedHeight="50" Brush="MPLobby.Armory.SwapMountCharacter.Button" IsVisible="@HasMount" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="150"/>
-              </Children>
-            </AL_CharacterTableauWidget>
+				<!-- Selected Character -->
+				<Widget Id="HeroPreview" DataSource="{HeroPreview}" DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
+					<Children>
 
-            <TextWidget DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Top" MarginTop="25" Brush="MPLobby.Armory.SelectionTitle" Text="@ClassName" />
-          </Children>
-        </Widget>
+						<AL_CharacterTableauWidget DataSource="{HeroVisual}" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="1500" SuggestedHeight="1150" HorizontalAlignment="Center" VerticalAlignment="Bottom" PositionYOffset="-25" BannerCodeText="@BannerCodeText" BodyProperties="@BodyProperties" CharStringId="@CharStringId" EquipmentCode="@EquipmentCode" IsFemale="@IsFemale" MountCreationKey="@MountCreationKey" StanceIndex="@StanceIndex" ArmorColor1="@ArmorColor1" Race="@Race" ArmorColor2="@ArmorColor2" IdleAction="@IdleAction" DoNotUseCustomScale="true" CustomAnimationProgressRatio="@CustomAnimationProgressRatio" IsPlayingCustomAnimations="@IsPlayingCustomAnimations" CustomAnimationWaitDuration="@CustomAnimationWaitDuration" CustomAnimation="@CustomAnimation" SwapPlacesButtonWidget="SwapPlacesButtonWidget" RightHandWieldedEquipmentIndex="@RightHandWieldedEquipmentIndex" LeftHandWieldedEquipmentIndex="@LeftHandWieldedEquipmentIndex">
+							<Children>
+								<ButtonWidget Id="SwapPlacesButtonWidget" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="50" SuggestedHeight="50" Brush="MPLobby.Armory.SwapMountCharacter.Button" IsVisible="@HasMount" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="150"/>
+							</Children>
+						</AL_CharacterTableauWidget>
 
-        <!-- Taunt Assignment Overlay -->
-        <Widget Id="TauntAssignmentOverlay" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="false">
-          <Children>
-            <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Sprite="BlankWhiteSquare_9" Color="#000000FF" AlphaFactor="0.1" />
-            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="65" Brush="MPLobby.Armory.TauntManagement.ClickToCloseText" Text="@TauntAssignmentClickToCloseText"/>
-          </Children>
-        </Widget>
+						<TextWidget DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Top" MarginTop="25" Brush="MPLobby.Armory.SelectionTitle" Text="@ClassName" />
+					</Children>
+				</Widget>
 
-        <!-- Action Buttons -->
-        <NavigationScopeTargeter ScopeID="ArmoryEditCharacterButtonScope" ScopeParent="..\EditCharacterButtonContainer" ScopeMovements="Vertical" />
-        <ListPanel Id="EditCharacterButtonContainer" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="40" StackLayout.LayoutMethod="VerticalTopToBottom" IsHidden="@IsTauntAssignmentActive">
-          <Children>
+				<!-- Taunt Assignment Overlay -->
+				<Widget Id="TauntAssignmentOverlay" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="false">
+					<Children>
+						<Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Sprite="BlankWhiteSquare_9" Color="#000000FF" AlphaFactor="0.1" />
+						<TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="65" Brush="MPLobby.Armory.TauntManagement.ClickToCloseText" Text="@TauntAssignmentClickToCloseText"/>
+					</Children>
+				</Widget>
 
-            <!-- Customize Character Button -->
-            <ButtonWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!CustomizeButton.Width" SuggestedHeight="!CustomizeButton.Height" HorizontalAlignment="Center" VerticalAlignment="Bottom" Brush="WideButton.Flat" Command.Click="ExecuteOpenFaceGen" IsVisible="@CanOpenFacegen" UpdateChildrenStates="true" GamepadNavigationIndex="0">
-              <Children>
-                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" PositionYOffset="1" Brush="MPTeamSelection.SpectateButton.Text" Text="@FacegenText" />
-              </Children>
-            </ButtonWidget>
+				<!-- Action Buttons -->
+				<NavigationScopeTargeter ScopeID="ArmoryEditCharacterButtonScope" ScopeParent="..\EditCharacterButtonContainer" ScopeMovements="Vertical" />
+				<ListPanel Id="EditCharacterButtonContainer" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="40" StackLayout.LayoutMethod="VerticalTopToBottom" IsHidden="@IsTauntAssignmentActive">
+					<Children>
 
-          </Children>
-        </ListPanel>
+						<!-- Customize Character Button -->
+						<ButtonWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!CustomizeButton.Width" SuggestedHeight="!CustomizeButton.Height" HorizontalAlignment="Center" VerticalAlignment="Bottom" Brush="WideButton.Flat" Command.Click="ExecuteOpenFaceGen" IsVisible="@CanOpenFacegen" UpdateChildrenStates="true" GamepadNavigationIndex="0">
+							<Children>
+								<TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" PositionYOffset="1" Brush="MPTeamSelection.SpectateButton.Text" Text="@FacegenText" />
+							</Children>
+						</ButtonWidget>
 
-        <!-- Taunt Slots -->
-        <NavigationScopeTargeter ScopeID="TauntSlotsNavigationScope" ScopeParent="..\TauntSlotsContainer" FollowMobileTargets="true" />
-        <Widget DoNotAcceptEvents="true" Id="TauntSlotsContainer" VisualDefinition="TauntSlotsContainer" UpdateChildrenStates="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="600" SuggestedHeight="600" HorizontalAlignment="Center" VerticalAlignment="Center" MarginRight="650" MarginBottom="520">
-          <Children>
-            <TauntCircleActionSelectorWidget DoNotAcceptEvents="true" Id="TauntsRadial" UpdateChildrenStates="true" DataSource="{Cosmetics\TauntSlots}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ActionContainer="ActionContainer" DirectionWidget="..\DirectionWidget" FallbackNavigationWidget="..\ManageTauntsButton" AllowInvalidSelection="true" ActivateOnlyWithController="true" >
-              <ItemTemplate>
-                <BrushWidget DoNotAcceptEvents="true" VisualDefinition="TauntRadialCircle" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="117" SuggestedHeight="115" HorizontalAlignment="Center" VerticalAlignment="Center" GamepadNavigationIndex="1" DoNotAcceptNavigation="true">
-                  <Children>
-                    <ButtonWidget Id="RadialButton" DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Command.Click="ExecuteSelect" Command.AlternateClick="ExecutePreview" Command.HoverBegin="ExecuteFocus" Command.HoverEnd="ExecuteUnfocus" IsSelected="@IsSelected" InputKeyContainerWidget="InputKeyContainer" TauntVisualBrushWidget="Background\Glow\RadialContent\IconParent\TauntIcon">
-                      <Children>
-                        <BoolBrushChangerBrushWidget Id="Background" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="Lobby.Radial.Item.Background.Padded" BooleanCheck="@IsAcceptingTaunts" TrueBrush="Lobby.Radial.Item.Background.Padded.Active" FalseBrush="Lobby.Radial.Item.Background.Padded" >
-                          <Children>
-                            <BoolBrushChangerBrushWidget Id="Glow" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" HorizontalAlignment="Center" VerticalAlignment="Center" IsSelected="@IsSelected" Brush="Lobby.Radial.Item.Glow" BooleanCheck="@IsAcceptingTaunts" TrueBrush="Lobby.Radial.Item.Glow.Active" FalseBrush="Lobby.Radial.Item.Glow">
-                              <Children>
-                                <Widget Id="RadialContent" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsHidden="@IsEmpty">
-                                  <Children>
-                                    <BoolStateChangerWidget Id="IconParent" VisualDefinition="TauntIcon" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="58" SuggestedHeight="58" VerticalAlignment="Center" HorizontalAlignment="Center" BooleanCheck="@IsEnabled" TrueState="TauntEnabled" FalseState="Default">
-                                      <Children>
-                                        <IconBrushWidget Id="TauntIcon" DataSource="{AssignedTauntItem}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="MPLobby.Armory.Cosmetic.Taunt" IconBrush="MPLobby.Armory.Cosmetic.Taunt.Icons" IconID="@TauntID" />
-                                      </Children>
-                                    </BoolStateChangerWidget>
-                                  </Children>
-                                </Widget>
+					</Children>
+				</ListPanel>
 
-                                <!-- Replace - Add Icon -->
-                                <Widget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="@IsAcceptingTaunts">
-                                  <Children>
-                                    <Widget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="@IsFocused">
-                                      <Children>
-                                        <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="70" SuggestedHeight="70" HorizontalAlignment="Center" VerticalAlignment="Center" IsHidden="@IsEmpty" Sprite="BlankWhiteCircle" Color="#00000080" />
-                                        <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="60" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Center" IsHidden="@IsEmpty" Sprite="StdAssets\replace_icon_big" Color="#FEC157FF" />
-                                        <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="60" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Center" TauntID="@TauntID" Sprite="StdAssets\plus_icon_big" Color="#FEC157FF" IsVisible="@IsEmpty" />
-                                      </Children>
-                                    </Widget>
-                                  </Children>
-                                </Widget>
-                              </Children>
-                            </BoolBrushChangerBrushWidget>
-                          </Children>
-                        </BoolBrushChangerBrushWidget>
-                        <Widget Id="InputKeyContainer" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" PositionYOffset="10" IsVisible="@IsFocused">
-                          <Children>
-                            <ListPanel DataSource="{EmptySlotKeyVisual}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" HorizontalAlignment="Left" MarginLeft="10" IsVisible="@IsVisible" >
-                              <Children>
-                                <InputKeyVisualWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="45" SuggestedHeight="45" KeyID="@KeyID" />
-                                <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="20" SuggestedHeight="20" VerticalAlignment="Center" Sprite="MPLobby\Generic\failed_icon" PositionXOffset="-5" Color="#b00808ff"/>
-                              </Children>
-                            </ListPanel>
-                            
-                            <ListPanel DataSource="{SelectKeyVisual}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" HorizontalAlignment="Right" MarginRight="10" IsVisible="@IsVisible" >
-                              <Children>
-                                <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="20" SuggestedHeight="20" VerticalAlignment="Center" Sprite="MPLobby\Generic\succeed_icon" PositionXOffset="5" Color="#9cf542ff"/>
-                                <InputKeyVisualWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="45" SuggestedHeight="45" KeyID="@KeyID" />
-                              </Children>
-                            </ListPanel>
-                          </Children>
-                        </Widget>
-                      </Children>
-                    </ButtonWidget>
+				<!-- Taunt Slots -->
+				<NavigationScopeTargeter ScopeID="TauntSlotsNavigationScope" ScopeParent="..\TauntSlotsContainer" FollowMobileTargets="true" />
+				<Widget DoNotAcceptEvents="true" Id="TauntSlotsContainer" VisualDefinition="TauntSlotsContainer" UpdateChildrenStates="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="600" SuggestedHeight="600" HorizontalAlignment="Center" VerticalAlignment="Center" MarginRight="650" MarginBottom="520">
+					<Children>
+						<TauntCircleActionSelectorWidget DoNotAcceptEvents="true" Id="TauntsRadial" UpdateChildrenStates="true" DataSource="{Cosmetics\TauntSlots}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ActionContainer="ActionContainer" DirectionWidget="..\DirectionWidget" FallbackNavigationWidget="..\ManageTauntsButton" AllowInvalidSelection="true" ActivateOnlyWithController="true" >
+							<ItemTemplate>
+								<BrushWidget DoNotAcceptEvents="true" VisualDefinition="TauntRadialCircle" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="117" SuggestedHeight="115" HorizontalAlignment="Center" VerticalAlignment="Center" GamepadNavigationIndex="1" DoNotAcceptNavigation="true">
+									<Children>
+										<ButtonWidget Id="RadialButton" DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Command.Click="ExecuteSelect" Command.AlternateClick="ExecutePreview" Command.HoverBegin="ExecuteFocus" Command.HoverEnd="ExecuteUnfocus" IsSelected="@IsSelected" InputKeyContainerWidget="InputKeyContainer" TauntVisualBrushWidget="Background\Glow\RadialContent\IconParent\TauntIcon">
+											<Children>
+												<BoolBrushChangerBrushWidget Id="Background" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="Lobby.Radial.Item.Background.Padded" BooleanCheck="@IsAcceptingTaunts" TrueBrush="Lobby.Radial.Item.Background.Padded.Active" FalseBrush="Lobby.Radial.Item.Background.Padded" >
+													<Children>
+														<BoolBrushChangerBrushWidget Id="Glow" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" HorizontalAlignment="Center" VerticalAlignment="Center" IsSelected="@IsSelected" Brush="Lobby.Radial.Item.Glow" BooleanCheck="@IsAcceptingTaunts" TrueBrush="Lobby.Radial.Item.Glow.Active" FalseBrush="Lobby.Radial.Item.Glow">
+															<Children>
+																<Widget Id="RadialContent" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsHidden="@IsEmpty">
+																	<Children>
+																		<BoolStateChangerWidget Id="IconParent" VisualDefinition="TauntIcon" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="58" SuggestedHeight="58" VerticalAlignment="Center" HorizontalAlignment="Center" BooleanCheck="@IsEnabled" TrueState="TauntEnabled" FalseState="Default">
+																			<Children>
+																				<IconBrushWidget Id="TauntIcon" DataSource="{AssignedTauntItem}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="MPLobby.Armory.Cosmetic.Taunt" IconBrush="MPLobby.Armory.Cosmetic.Taunt.Icons" IconID="@TauntID" />
+																			</Children>
+																		</BoolStateChangerWidget>
+																	</Children>
+																</Widget>
 
-                  </Children>
-                </BrushWidget>
-              </ItemTemplate>
-            </TauntCircleActionSelectorWidget>
-            
-            <Widget Id="DirectionWidget" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="13" SuggestedHeight="13" HorizontalAlignment="Center" VerticalAlignment="Center" Sprite="BlankWhiteCircle" AlphaFactor="0.3"/>
+																<!-- Replace - Add Icon -->
+																<Widget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="@IsAcceptingTaunts">
+																	<Children>
+																		<Widget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="@IsFocused">
+																			<Children>
+																				<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="70" SuggestedHeight="70" HorizontalAlignment="Center" VerticalAlignment="Center" IsHidden="@IsEmpty" Sprite="BlankWhiteCircle" Color="#00000080" />
+																				<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="60" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Center" IsHidden="@IsEmpty" Sprite="StdAssets\replace_icon_big" Color="#FEC157FF" />
+																				<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="60" SuggestedHeight="60" HorizontalAlignment="Center" VerticalAlignment="Center" TauntID="@TauntID" Sprite="StdAssets\plus_icon_big" Color="#FEC157FF" IsVisible="@IsEmpty" />
+																			</Children>
+																		</Widget>
+																	</Children>
+																</Widget>
+															</Children>
+														</BoolBrushChangerBrushWidget>
+													</Children>
+												</BoolBrushChangerBrushWidget>
+												<Widget Id="InputKeyContainer" DoNotAcceptEvents="true" DoNotPassEventsToChildren="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" PositionYOffset="10" IsVisible="@IsFocused">
+													<Children>
+														<ListPanel DataSource="{EmptySlotKeyVisual}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" HorizontalAlignment="Left" MarginLeft="10" IsVisible="@IsVisible" >
+															<Children>
+																<InputKeyVisualWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="45" SuggestedHeight="45" KeyID="@KeyID" />
+																<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="20" SuggestedHeight="20" VerticalAlignment="Center" Sprite="MPLobby\Generic\failed_icon" PositionXOffset="-5" Color="#b00808ff"/>
+															</Children>
+														</ListPanel>
 
-            <!-- Manage Taunts Button -->
-            <Widget Id="ManageTauntsButton" VisualDefinition="ManageTauntsButton" DoNotAcceptEvents="true" UpdateChildrenStates="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="150" SuggestedHeight="150" HorizontalAlignment="Center" VerticalAlignment="Center" ExtendCursorAreaLeft="-35" ExtendCursorAreaRight="-35" ExtendCursorAreaTop="-50" ExtendCursorAreaBottom="-50">
-              <Children>
-                <ButtonWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" GamepadNavigationIndex="0" Command.Click="ExecuteToggleManageTauntsState">
-                  <Children>
-                    <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="150" SuggestedHeight="150" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="Manage.Taunts.Button.Background" UpdateChildrenStates="true"  >
-                      <Children>
-                        <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="100" HorizontalAlignment="Center" PositionYOffset="1" Brush="MPLobby.Manage.Taunts.Button.Text" Text="@ManageTauntsText" />
-                      </Children>
-                    </BrushWidget>
-                  </Children>
-                </ButtonWidget>
-              </Children>
-            </Widget>
+														<ListPanel DataSource="{SelectKeyVisual}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" HorizontalAlignment="Right" MarginRight="10" IsVisible="@IsVisible" >
+															<Children>
+																<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="20" SuggestedHeight="20" VerticalAlignment="Center" Sprite="MPLobby\Generic\succeed_icon" PositionXOffset="5" Color="#9cf542ff"/>
+																<InputKeyVisualWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="45" SuggestedHeight="45" KeyID="@KeyID" />
+															</Children>
+														</ListPanel>
+													</Children>
+												</Widget>
+											</Children>
+										</ButtonWidget>
 
-          </Children>
-        </Widget>
-        
-        <!-- Left Side -->
-        <ListPanel VisualDefinition="LeftSideVisuals" Id="LeftSideParent" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" StackLayout.LayoutMethod="VerticalTopToBottom">
-          <Children>
-            <Lobby.ClassFilter DataSource="{ClassFilter}" MarginLeft="50" Parameter.IsNavigationDisabled="@IsManagingTaunts" />
+									</Children>
+								</BrushWidget>
+							</ItemTemplate>
+						</TauntCircleActionSelectorWidget>
 
-            <NavigationScopeTargeter ScopeID="ArmoryPerksPanelScope" ScopeParent="..\PerksPanel" ScopeMovements="Horizontal" IsScopeDisabled="@IsManagingTaunts" />
-            <MultiplayerPerkContainerPanelWidget DataSource="{HeroPerkSelection}" Id="PerksPanel" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginLeft="45" PopupWidgetFirst="..\..\PerkPopupsParent\FirstPerks" PopupWidgetSecond="..\..\PerkPopupsParent\SecondPerks" PopupWidgetThird="..\..\PerkPopupsParent\ThirdPerks">
-              <Children>
+						<Widget Id="DirectionWidget" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="13" SuggestedHeight="13" HorizontalAlignment="Center" VerticalAlignment="Center" Sprite="BlankWhiteCircle" AlphaFactor="0.3"/>
 
-                <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!Perks.Background.Width" SuggestedHeight="!Perks.Background.Height" HorizontalAlignment="Center" Sprite="MPLobby\Armory\perks_frame" Color="#F6A554FF" IsEnabled="false" />
+						<!-- Manage Taunts Button -->
+						<Widget Id="ManageTauntsButton" VisualDefinition="ManageTauntsButton" DoNotAcceptEvents="true" UpdateChildrenStates="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="150" SuggestedHeight="150" HorizontalAlignment="Center" VerticalAlignment="Center" ExtendCursorAreaLeft="-35" ExtendCursorAreaRight="-35" ExtendCursorAreaTop="-50" ExtendCursorAreaBottom="-50">
+							<Children>
+								<ButtonWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" GamepadNavigationIndex="0" Command.Click="ExecuteToggleManageTauntsState">
+									<Children>
+										<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="150" SuggestedHeight="150" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="Manage.Taunts.Button.Background" UpdateChildrenStates="true"  >
+											<Children>
+												<TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="100" HorizontalAlignment="Center" PositionYOffset="1" Brush="MPLobby.Manage.Taunts.Button.Text" Text="@ManageTauntsText" />
+											</Children>
+										</BrushWidget>
+									</Children>
+								</ButtonWidget>
+							</Children>
+						</Widget>
 
-                <NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
-                  <ItemTemplate>
-                    <MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="160" SuggestedHeight="100" HorizontalAlignment="Center" MarginLeft="5" MarginTop="15" MarginBottom="3" Brush="MPLobby.Perks.Button" ContainerPanel="..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
-                      <Children>
-                        <BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="10" Brush="MPLobby.Perks.Icon">
-                          <Children>
-                            <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPLobby.Perks.Frame" />
-                          </Children>
-                        </BrushWidget>
-                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" HorizontalAlignment="Center" SuggestedHeight="42" VerticalAlignment="Bottom" MarginTop="5" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
-                        <HintWidget DataSource="{Hint}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" />
-                      </Children>
-                    </MultiplayerPerkItemToggleWidget>
-                  </ItemTemplate>
-                </NavigatableListPanel>
-              </Children>
-            </MultiplayerPerkContainerPanelWidget>
-            <!-- Troop Cost -->
-            <Widget DataSource="{ClassStats}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginLeft="60">
-              <Children>
-                <ListPanel DataSource="{CostHint}" DoNotPassEventsToChildren="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="50" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginTop="10" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint">
-                  <Children>
-                    <TextWidget DataSource="{..}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Center" MarginRight="5" Brush="MPClassLoadout.TotalGoldText" IntText="@Cost" />
-                    <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="29" SuggestedHeight="28" HorizontalAlignment="Right" VerticalAlignment="Center" Sprite="MPLobby\Armory\bracelet" />
-                  </Children>
-                </ListPanel>
-              </Children>
-            </Widget>
-          </Children>
-        </ListPanel>
+					</Children>
+				</Widget>
 
-        <!-- Game Modes -->
-        <NavigationScopeTargeter ScopeID="ArmoryGameModesScope" ScopeParent="..\GameModesDropdownParent" ScopeMovements="Vertical" ExtendDiscoveryAreaLeft="18" IsScopeDisabled="@IsManagingTaunts" />
-        <ListPanelDropdownWidget VisualDefinition="LeftSideDropdownVisuals" Id="GameModesDropdownParent" DataSource="{HeroPerkSelection\GameModes}" WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="190" MarginTop="10" MarginLeft="500" DoNotHandleDropdownListPanel="true" CurrentSelectedIndex="@SelectedIndex" Button="DropdownButton" ListPanelContainer="ListContainer" ListPanel="ListContainer\PrimaryUsageSelectorList" TextWidget="DropdownButton\Container\ContainerChild\SelectedTextWidget" GamepadNavigationIndex="0" IsHidden="@IsManagingTaunts">
-          <Children>
-            <ButtonWidget Id="DropdownButton" Type="Toggle" DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="40" HorizontalAlignment="Right" VerticalAlignment="Top">
-              <Children>
-                <Widget Id="Container" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Center">
-                  <Children>
-                    <BrushWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="30" Brush="MPLobby.GameMode.Dropdown.BG"/>
-                    <ListPanel Id="ContainerChild" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Center">
-                      <Children>
-                        <RichTextWidget Id="SelectedTextWidget" Text=" " WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" MaxWidth="200" HorizontalAlignment="Left" VerticalAlignment="Center" MarginLeft="5" PositionYOffset="-2" Brush="MPLobby.GameMode.Dropdown.Text"/>
-                        <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="12" SuggestedHeight="12" VerticalAlignment="Center" MarginLeft="7" PositionYOffset="-2" Brush="MPLobby.GameMode.Dropdown.Arrow"/>
-                      </Children>
-                    </ListPanel>
-                  </Children>
-                </Widget>
-              </Children>
-            </ButtonWidget>
-            <Widget Id="ListContainer" IsVisible="false" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginTop="40" Sprite="region_combobox_bg_9" Color="#000000FF" AlphaFactor="0.9">
-              <Children>
-                <ListPanel Id="PrimaryUsageSelectorList" DataSource="{ItemList}" IsVisible="false" LayoutImp.LayoutMethod="VerticalTopToBottom" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Top" HorizontalAlignment="Left" MarginTop="20" MarginBottom="10" MinIndex="1">
-                  <ItemTemplate>
-                    <ButtonWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy ="Fixed" SuggestedHeight="30" HorizontalAlignment="Center" VerticalAlignment="Bottom" ButtonType="Radio" Brush="MPLobby.Matchmaking.Region.DropdownItem" IsHidden="@IsRegionNone">
-                      <Children>
-                        <ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginLeft="10" MarginRight="10">
-                          <Children>
-                            <RichTextWidget Text="@StringItem" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPLobby.Matchmaking.Region.ItemText"/>
-                          </Children>
-                        </ListPanel>
-                      </Children>
-                    </ButtonWidget>
-                  </ItemTemplate>
-                </ListPanel>
-                <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="210" SuggestedHeight="!DropdownHeader.Height" HorizontalAlignment="Center" PositionYOffset="-3" Sprite="MPLobby\Matchmaking\region_combobox_header" />
-              </Children>
-            </Widget>
-          </Children>
-        </ListPanelDropdownWidget>
+				<!-- Left Side -->
+				<ListPanel VisualDefinition="LeftSideVisuals" Id="LeftSideParent" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" StackLayout.LayoutMethod="VerticalTopToBottom">
+					<Children>
+						<Lobby.ClassFilter DataSource="{ClassFilter}" MarginLeft="50" Parameter.IsNavigationDisabled="@IsManagingTaunts" />
 
-        <!-- Right Side -->
-        <Widget Id="RightSideParent" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="550" HorizontalAlignment="Right" MarginRight="10" MarginTop="35" MarginBottom="110">
-          <Children>
+						<NavigationScopeTargeter ScopeID="ArmoryPerksPanelScope" ScopeParent="..\PerksPanel" ScopeMovements="Horizontal" IsScopeDisabled="@IsManagingTaunts" />
+						<MultiplayerPerkContainerPanelWidget DataSource="{HeroPerkSelection}" Id="PerksPanel" WidthSizePolicy="Fixed" SuggestedWidth="310" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginLeft="45" PopupWidgetFirst="..\..\PerkPopupsParent\FirstPerks" PopupWidgetSecond="..\..\PerkPopupsParent\SecondPerks" PopupWidgetThird="..\..\PerkPopupsParent\ThirdPerks">
+							<Children>
 
-            <NavigationScopeTargeter ScopeID="ArmoryRightPanelTabsScope" ScopeParent="..\ArmoryRightPanelTabs" ScopeMovements="Horizontal" />
-            <ListPanel Id="ArmoryRightPanelTabs" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginLeft="0" MarginRight="15" LayoutImp.LayoutMethod="HorizontalSpaced" IsHidden="@IsManagingTaunts">
-              <Children>
-                <TabToggleWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" TabControlWidget="..\..\RightAreaTabControl" TabName="CosmeticsTab" GamepadNavigationIndex="0">
-                  <Children>
-                    <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPLobby.Armory.TabText" Text="@CustomizationText" />
-                  </Children>
-                </TabToggleWidget>
+								<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!Perks.Background.Width" SuggestedHeight="!Perks.Background.Height" HorizontalAlignment="Center" Sprite="MPLobby\Armory\perks_frame" Color="#F6A554FF" IsEnabled="false" />
 
-                <TabToggleWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" TabControlWidget="..\..\RightAreaTabControl" TabName="StatsTab" GamepadNavigationIndex="1" >
-                  <Children>
-                    <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPLobby.Armory.TabText" Text="@StatsText" />
-                  </Children>
-                </TabToggleWidget>
-              </Children>
-            </ListPanel>
+								<ScrollablePanel Id="PerksScrollPanel" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="310" SuggestedHeight="120" HorizontalAlignment="Center" AutoHideScrollBars="true" HorizontalScrollbar="..\PerksScrollbarContainer\PerksScrollbar" InnerPanel="PerksClipRect\Perks" ClipRect="PerksClipRect">
+									<Children>
+										<Widget Id="PerksClipRect" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
+											<Children>
+												<NavigationScopeTargeter Id="ScopeTargeter" ScopeID="ClassSelectionPerksScope" ScopeParent="..\Perks" ScopeMovements="Horizontal" />
+												<NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+													<ItemTemplate>
+														<MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="80" HorizontalAlignment="Center" MarginLeft="5" Brush="MPClassLoadout.Perks.Button" ContainerPanel="..\..\..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
+															<Children>
+																<BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="18" Brush="MPClassLoadout.Perks.Icon" >
+																	<Children>
+																		<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
+																	</Children>
+																</BrushWidget>
+																<TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="25" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="8" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
+															</Children>
+														</MultiplayerPerkItemToggleWidget>
+													</ItemTemplate>
+												</NavigatableListPanel>
+											</Children>
+										</Widget>
+									</Children>
+								</ScrollablePanel>
+								<Widget Id="PerksScrollbarContainer" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="250" SuggestedHeight="4" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="2">
+									<Children>
+										<ScrollbarWidget Id="PerksScrollbar" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" AlignmentAxis="Horizontal" Handle="PerksScrollbarHandle" MaxValue="100" MinValue="0" UpdateChildrenStates="true">
+											<Children>
+												<Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="2" HorizontalAlignment="Center" Sprite="lobby_slider_bed_9" AlphaFactor="0.2" />
+												<ImageWidget Id="PerksScrollbarHandle" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="4" HorizontalAlignment="Center" Brush="MPLobby.CustomServer.ScrollHandle" MinWidth="40" />
+											</Children>
+										</ScrollbarWidget>
+									</Children>
+								</Widget>
 
-            <TabControl Id="RightAreaTabControl" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginTop="35" SelectedIndex="1">
-              <Children>
+							</Children>
+						</MultiplayerPerkContainerPanelWidget>
 
-                <!-- Stats -->
-                <Lobby.Armory.ClassStats Id="StatsTab" DataSource="{ClassStats}" />
+						<!-- Troop Cost -->
+						<Widget DataSource="{ClassStats}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginLeft="60">
+							<Children>
+								<ListPanel DataSource="{CostHint}" DoNotPassEventsToChildren="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="50" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginTop="10" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint">
+									<Children>
+										<TextWidget DataSource="{..}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Center" MarginRight="5" Brush="MPClassLoadout.TotalGoldText" IntText="@Cost" />
+										<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="29" SuggestedHeight="28" HorizontalAlignment="Right" VerticalAlignment="Center" Sprite="MPLobby\Armory\bracelet" />
+									</Children>
+								</ListPanel>
+							</Children>
+						</Widget>
+					</Children>
+				</ListPanel>
 
-                <!-- Cosmetics -->
-                <Lobby.Armory.Cosmetics Id="CosmeticsTab" DataSource="{Cosmetics}" />
+				<!-- Game Modes -->
+				<NavigationScopeTargeter ScopeID="ArmoryGameModesScope" ScopeParent="..\GameModesDropdownParent" ScopeMovements="Vertical" ExtendDiscoveryAreaLeft="18" IsScopeDisabled="@IsManagingTaunts" />
+				<ListPanelDropdownWidget VisualDefinition="LeftSideDropdownVisuals" Id="GameModesDropdownParent" DataSource="{HeroPerkSelection\GameModes}" WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="190" MarginTop="10" MarginLeft="500" DoNotHandleDropdownListPanel="true" CurrentSelectedIndex="@SelectedIndex" Button="DropdownButton" ListPanelContainer="ListContainer" ListPanel="ListContainer\PrimaryUsageSelectorList" TextWidget="DropdownButton\Container\ContainerChild\SelectedTextWidget" GamepadNavigationIndex="0" IsHidden="@IsManagingTaunts">
+					<Children>
+						<ButtonWidget Id="DropdownButton" Type="Toggle" DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="40" HorizontalAlignment="Right" VerticalAlignment="Top">
+							<Children>
+								<Widget Id="Container" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Center">
+									<Children>
+										<BrushWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="30" Brush="MPLobby.GameMode.Dropdown.BG"/>
+										<ListPanel Id="ContainerChild" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Center">
+											<Children>
+												<RichTextWidget Id="SelectedTextWidget" Text=" " WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" MaxWidth="200" HorizontalAlignment="Left" VerticalAlignment="Center" MarginLeft="5" PositionYOffset="-2" Brush="MPLobby.GameMode.Dropdown.Text"/>
+												<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="12" SuggestedHeight="12" VerticalAlignment="Center" MarginLeft="7" PositionYOffset="-2" Brush="MPLobby.GameMode.Dropdown.Arrow"/>
+											</Children>
+										</ListPanel>
+									</Children>
+								</Widget>
+							</Children>
+						</ButtonWidget>
+						<Widget Id="ListContainer" IsVisible="false" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginTop="40" Sprite="region_combobox_bg_9" Color="#000000FF" AlphaFactor="0.9">
+							<Children>
+								<ListPanel Id="PrimaryUsageSelectorList" DataSource="{ItemList}" IsVisible="false" LayoutImp.LayoutMethod="VerticalTopToBottom" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Top" HorizontalAlignment="Left" MarginTop="20" MarginBottom="10" MinIndex="1">
+									<ItemTemplate>
+										<ButtonWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy ="Fixed" SuggestedHeight="30" HorizontalAlignment="Center" VerticalAlignment="Bottom" ButtonType="Radio" Brush="MPLobby.Matchmaking.Region.DropdownItem" IsHidden="@IsRegionNone">
+											<Children>
+												<ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginLeft="10" MarginRight="10">
+													<Children>
+														<RichTextWidget Text="@StringItem" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPLobby.Matchmaking.Region.ItemText"/>
+													</Children>
+												</ListPanel>
+											</Children>
+										</ButtonWidget>
+									</ItemTemplate>
+								</ListPanel>
+								<Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="210" SuggestedHeight="!DropdownHeader.Height" HorizontalAlignment="Center" PositionYOffset="-3" Sprite="MPLobby\Matchmaking\region_combobox_header" />
+							</Children>
+						</Widget>
+					</Children>
+				</ListPanelDropdownWidget>
 
-              </Children>
-            </TabControl>
+				<!-- Right Side -->
+				<Widget Id="RightSideParent" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="550" HorizontalAlignment="Right" MarginRight="10" MarginTop="35" MarginBottom="110">
+					<Children>
 
-          </Children>
-        </Widget>
+						<NavigationScopeTargeter ScopeID="ArmoryRightPanelTabsScope" ScopeParent="..\ArmoryRightPanelTabs" ScopeMovements="Horizontal" />
+						<ListPanel Id="ArmoryRightPanelTabs" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginLeft="0" MarginRight="15" LayoutImp.LayoutMethod="HorizontalSpaced" IsHidden="@IsManagingTaunts">
+							<Children>
+								<TabToggleWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" TabControlWidget="..\..\RightAreaTabControl" TabName="CosmeticsTab" GamepadNavigationIndex="0">
+									<Children>
+										<TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPLobby.Armory.TabText" Text="@CustomizationText" />
+									</Children>
+								</TabToggleWidget>
 
-        <Widget Id="PerkPopupsParent" DataSource="{HeroPerkSelection}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" DoNotAcceptEvents="true">
-          <Children>
-            <MPLobbyPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{Perks\0\CandidatePerks}" ShowAboveContainer="true"/>
-            <MPLobbyPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{Perks\1\CandidatePerks}" ShowAboveContainer="true"/>
-            <MPLobbyPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{Perks\2\CandidatePerks}" ShowAboveContainer="true"/>
-          </Children>
-        </Widget>
+								<TabToggleWidget DoNotPassEventsToChildren="true" UpdateChildrenStates="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" TabControlWidget="..\..\RightAreaTabControl" TabName="StatsTab" GamepadNavigationIndex="1" >
+									<Children>
+										<TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPLobby.Armory.TabText" Text="@StatsText" />
+									</Children>
+								</TabToggleWidget>
+							</Children>
+						</ListPanel>
 
-        <NavigationScopeTargeter ScopeID="ArmoryCenterScope" ScopeParent="..\ArmoryCenterNavigationWidget" IsScopeDisabled="@IsTauntAssignmentActive" />
-        <Widget Id="ArmoryCenterNavigationWidget" DoNotAcceptEvents="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="100" SuggestedHeight="100" HorizontalAlignment="Center" VerticalAlignment="Center" PositionYOffset="-150" GamepadNavigationIndex="0" />
+						<TabControl Id="RightAreaTabControl" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginTop="35" SelectedIndex="1">
+							<Children>
 
-      </Children>
-    </MultiplayerArmoryPageWidget>
-  </Window>
+								<!-- Stats -->
+								<Lobby.Armory.ClassStats Id="StatsTab" DataSource="{ClassStats}" />
+
+								<!-- Cosmetics -->
+								<Lobby.Armory.Cosmetics Id="CosmeticsTab" DataSource="{Cosmetics}" />
+
+							</Children>
+						</TabControl>
+
+					</Children>
+				</Widget>
+
+				<Widget Id="PerkPopupsParent" DataSource="{HeroPerkSelection}" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" DoNotAcceptEvents="true">
+					<Children>
+						<MultiplayerClassLoadoutPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{Perks\0\CandidatePerks}" ShowAboveContainer="true"/>
+						<MultiplayerClassLoadoutPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{Perks\1\CandidatePerks}" ShowAboveContainer="true"/>
+						<MultiplayerClassLoadoutPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{Perks\2\CandidatePerks}" ShowAboveContainer="true"/>
+					</Children>
+				</Widget>
+
+				<NavigationScopeTargeter ScopeID="ArmoryCenterScope" ScopeParent="..\ArmoryCenterNavigationWidget" IsScopeDisabled="@IsTauntAssignmentActive" />
+				<Widget Id="ArmoryCenterNavigationWidget" DoNotAcceptEvents="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="100" SuggestedHeight="100" HorizontalAlignment="Center" VerticalAlignment="Center" PositionYOffset="-150" GamepadNavigationIndex="0" />
+
+			</Children>
+		</MultiplayerArmoryPageWidget>
+	</Window>
 </Prefab>

--- a/Alliance.Client/_Module/GUI/Prefabs/TroopSpawnMenu/TroopGroup.xml
+++ b/Alliance.Client/_Module/GUI/Prefabs/TroopSpawnMenu/TroopGroup.xml
@@ -45,23 +45,41 @@
                   <Children>
 
                     <!--Perks-->
-                    <MultiplayerPerkContainerPanelWidget Id="PerksPanel" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" PositionXOffset="2" PerkInputBlocker="..\PerkInputBlocker" PopupWidgetFirst="..\..\..\..\..\..\..\..\..\..\FirstPerks" PopupWidgetSecond="..\..\..\..\..\..\..\..\..\..\SecondPerks" PopupWidgetThird="..\..\..\..\..\..\..\..\..\..\ThirdPerks" TroopTupleBodyWidget="..\..\Body" NavigationScopeTargeter="ScopeTargeter">
+                    <MultiplayerPerkContainerPanelWidget Id="PerksPanel" WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="500" HorizontalAlignment="Center" PositionXOffset="2" PerkInputBlocker="..\PerkInputBlocker" PopupWidgetFirst="..\..\..\..\..\..\..\..\..\..\FirstPerks" PopupWidgetSecond="..\..\..\..\..\..\..\..\..\..\SecondPerks" PopupWidgetThird="..\..\..\..\..\..\..\..\..\..\ThirdPerks" TroopTupleBodyWidget="..\..\Body" NavigationScopeTargeter="ScopeTargeter">
                       <Children>
-                        <NavigationScopeTargeter Id="ScopeTargeter" ScopeID="ClassSelectionPerksScope" ScopeParent="..\Perks" ScopeMovements="Horizontal" />
-                        <NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
-                          <ItemTemplate>
-                            <MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="160" HorizontalAlignment="Center" MarginLeft="5" Brush="MPClassLoadout.Perks.Button" ContainerPanel="..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
+                        <ScrollablePanel Id="PerksScrollPanel" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="500" SuggestedHeight="96" HorizontalAlignment="Center" AutoHideScrollBars="true" HorizontalScrollbar="..\PerksScrollbarContainer\PerksScrollbar" InnerPanel="PerksClipRect\Perks" ClipRect="PerksClipRect">
+                          <Children>
+                            <Widget Id="PerksClipRect" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
                               <Children>
-                                <BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="18" Brush="MPClassLoadout.Perks.Icon">
-                                  <Children>
-                                    <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
-                                  </Children>
-                                </BrushWidget>
-                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="25" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="8" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
+                                <NavigationScopeTargeter Id="ScopeTargeter" ScopeID="ClassSelectionPerksScope" ScopeParent="..\Perks" ScopeMovements="Horizontal" />
+                                <NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+                                  <ItemTemplate>
+                                    <MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="160" HorizontalAlignment="Center" MarginLeft="5" Brush="MPClassLoadout.Perks.Button" ContainerPanel="..\..\..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
+                                      <Children>
+                                        <BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="18" Brush="MPClassLoadout.Perks.Icon">
+                                          <Children>
+                                            <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
+                                          </Children>
+                                        </BrushWidget>
+                                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="25" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="8" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
+                                      </Children>
+                                    </MultiplayerPerkItemToggleWidget>
+                                  </ItemTemplate>
+                                </NavigatableListPanel>
                               </Children>
-                            </MultiplayerPerkItemToggleWidget>
-                          </ItemTemplate>
-                        </NavigatableListPanel>
+                            </Widget>
+                          </Children>
+                        </ScrollablePanel>
+                        <Widget Id="PerksScrollbarContainer" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="430" SuggestedHeight="4" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="2">
+                          <Children>
+                            <ScrollbarWidget Id="PerksScrollbar" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" AlignmentAxis="Horizontal" Handle="PerksScrollbarHandle" MaxValue="100" MinValue="0" UpdateChildrenStates="true">
+                              <Children>
+                                <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="2" HorizontalAlignment="Center" Sprite="lobby_slider_bed_9" AlphaFactor="0.2" />
+                                <ImageWidget Id="PerksScrollbarHandle" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="4" HorizontalAlignment="Center" Brush="MPLobby.CustomServer.ScrollHandle" MinWidth="40" />
+                              </Children>
+                            </ScrollbarWidget>
+                          </Children>
+                        </Widget>
                       </Children>
                     </MultiplayerPerkContainerPanelWidget>
 

--- a/Alliance.Client/_Module/GUI/Prefabs/TroopSpawnMenu/TroopSpawnMenu.xml
+++ b/Alliance.Client/_Module/GUI/Prefabs/TroopSpawnMenu/TroopSpawnMenu.xml
@@ -35,9 +35,9 @@
 						<Footer WidthSizePolicy="Fixed" SuggestedWidth="1500" HeightSizePolicy ="Fixed" SuggestedHeight="150" HorizontalAlignment="Center" VerticalAlignment="Bottom" />
 
 						<!-- Selected perks -->
-						<MultiplayerClassLoadoutPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\FirstPerk\CandidatePerks}" MarginTop="-90" MarginLeft="-220"/>
-						<MultiplayerClassLoadoutPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\SecondPerk\CandidatePerks}" MarginTop="-90" MarginLeft="-220"/>
-						<MultiplayerClassLoadoutPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\ThirdPerk\CandidatePerks}"  MarginTop="-90" MarginLeft="-220"/>
+						<MultiplayerClassLoadoutPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\FirstPerk\CandidatePerks}" MarginTop="-90" MarginLeft="-180"/>
+						<MultiplayerClassLoadoutPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\SecondPerk\CandidatePerks}" MarginTop="-90" MarginLeft="-180"/>
+						<MultiplayerClassLoadoutPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{SelectedTroopVM\ThirdPerk\CandidatePerks}"  MarginTop="-90" MarginLeft="-180"/>
 
 					</Children>
 				</BrushWidget>

--- a/Alliance.Client/_Module/SubModule.xml
+++ b/Alliance.Client/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance" />
   <Name value="Alliance" />
-  <Version value="v0.5.6.0" />
+  <Version value="v0.5.7.0" />
   <ModuleCategory value="Multiplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.Common/CommonProps.props
+++ b/Alliance.Common/CommonProps.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<AllianceVersion>0.5.6.0</AllianceVersion>
+		<AllianceVersion>0.5.7.0</AllianceVersion>
 	</PropertyGroup>
 </Project>

--- a/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
+++ b/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
@@ -13,7 +13,7 @@ namespace Alliance.Common.Core.Configuration.Models
 		[ConfigProperty(true, "Localized armor", "Enable localized armor system for bots and players.", category: "General")]
 		public bool LocalizedArmor = true;
 		[ConfigProperty(true, "Time before start", "Duration in seconds during which players are stuck in starting zone.", 0, 600, category: "General")]
-		public int TimeBeforeStart = 30;
+		public int ElectionTimer = 30;
 		[ConfigProperty(true, "Allow spawn during round", "Allow players to spawn while round is in progress.", category: "General")]
 		public bool AllowSpawnInRound = true;
 		[ConfigProperty(true, "Free respawn timer", "Duration in seconds during which players can freely respawn after round start.", 0, 3600, category: "General")]

--- a/Alliance.Common/Core/Security/Extension/RolesExtension.cs
+++ b/Alliance.Common/Core/Security/Extension/RolesExtension.cs
@@ -22,7 +22,7 @@ namespace Alliance.Common.Core.Security.Extension
 			Team team = player.GetComponent<MissionPeer>()?.Team;
 			bool validTeam = team == Mission.Current.AttackerTeam || team == Mission.Current.DefenderTeam;
 			bool isCvC = MultiplayerOptions.OptionType.GameType.GetStrValue() == "CvC";
-			bool isPvCCommanderSide = MultiplayerOptions.OptionType.GameType.GetStrValue() == "PvC" && Config.Instance.CommanderSide == team.Side.ToString();
+			bool isPvCCommanderSide = MultiplayerOptions.OptionType.GameType.GetStrValue() == "PvC" && Config.Instance.CommanderSide == team?.Side.ToString();
 			return validTeam && (isCvC || isPvCCommanderSide);
 		}
 

--- a/Alliance.Common/Core/Utils/CoreBehavior.cs
+++ b/Alliance.Common/Core/Utils/CoreBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Alliance.Common.Core.Configuration;
 using Alliance.Common.Core.Configuration.Models;
+using Alliance.Common.Extensions.TroopSpawner.Models;
 using TaleWorlds.Engine;
 using TaleWorlds.InputSystem;
 using TaleWorlds.Library;
@@ -43,6 +44,11 @@ namespace Alliance.Common.Core.Utils
 				}
 #endif
 			}
+		}
+
+		protected override void OnEndMission()
+		{
+			FormationControlModel.Instance.Clear();
 		}
 	}
 }

--- a/Alliance.Common/Extensions/PlayerSpawn/Models/PlayerSpawnMenu.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/Models/PlayerSpawnMenu.cs
@@ -491,7 +491,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.Models
 					Log($"Loading PlayerSpawnMenu from {filePath}");
 					playerSpawnMenu = SerializeHelper.LoadClassFromFile(filePath, new PlayerSpawnMenu());
 					playerSpawnMenu.RefreshIndices(); // Ensure indices are unique and valid
-					return true;
+					return playerSpawnMenu.CheckCharacterValidity();
 				}
 				else
 				{
@@ -503,6 +503,26 @@ namespace Alliance.Common.Extensions.PlayerSpawn.Models
 				Log($"Failed to load PlayerSpawnMenu from {filePath}: {ex.Message}", LogLevel.Error);
 			}
 			return false;
+		}
+
+		private bool CheckCharacterValidity()
+		{
+			bool validity = true;
+			foreach (PlayerTeam team in Teams)
+			{				
+				foreach (PlayerFormation formation in team.Formations)
+				{
+					foreach (AvailableCharacter character in formation.AvailableCharacters)
+					{
+						if(character.CharacterStub == null)
+						{
+							Log($"Character {character.Name} in formation {formation.Name} of team {team.Name} is invalid (CharacterStub is null).", LogLevel.Error);
+							return false;
+						}
+					}
+				}
+			}
+			return validity;
 		}
 
 		/// <summary>

--- a/Alliance.Common/Extensions/PlayerSpawn/ViewModels/PlayerSpawnMenuVM.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/ViewModels/PlayerSpawnMenuVM.cs
@@ -15,12 +15,10 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using TaleWorlds.Core;
-using TaleWorlds.GauntletUI;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
 using TaleWorlds.ModuleManager;
 using TaleWorlds.MountAndBlade;
-using TaleWorlds.MountAndBlade.Diamond;
 using static Alliance.Common.Utilities.Logger;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.ViewModels
@@ -54,6 +52,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.ViewModels
 		private float _timeBeforeOfficerElection;
 		private string _formationInfoText;
 		private bool _showTroops;
+		private bool _forceHidePerkPopups = true;
 		private string _playerSpawnInfo;
 		private float _timeBeforeSpawn;
 		private bool _showSpawnInfo;
@@ -159,6 +158,20 @@ namespace Alliance.Common.Extensions.PlayerSpawn.ViewModels
 				{
 					_showTroops = value;
 					OnPropertyChangedWithValue(value, nameof(ShowTroops));
+				}
+			}
+		}
+
+		[DataSourceProperty]
+		public bool ForceHidePerkPopups
+		{
+			get => _forceHidePerkPopups;
+			set
+			{
+				if (value != _forceHidePerkPopups)
+				{
+					_forceHidePerkPopups = value;
+					OnPropertyChangedWithValue(value, nameof(ForceHidePerkPopups));
 				}
 			}
 		}
@@ -655,6 +668,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.ViewModels
 		{
 			if (formationVM != null)
 			{
+				if (SelectedCharacterVM != null) ClearCharacterSelection();
 				if (SelectedFormationVM != null) SelectedFormationVM.IsSelected = false;
 				_selectedFormationVM = formationVM;
 				formationVM.IsSelected = true;
@@ -834,16 +848,18 @@ namespace Alliance.Common.Extensions.PlayerSpawn.ViewModels
 			SelectedCharacterVM.RefreshValues();
 			SelectedFormationVM.RefreshValues();
 			ShowSpawnInfo = true;
+			ForceHidePerkPopups = false;
 		}
 
 		private void ClearCharacterSelection()
 		{
+			ForceHidePerkPopups = true;
 			if (SelectedCharacterVM != null)
 			{
 				_previouslySelectedCharacterVM = SelectedCharacterVM;
 				_previouslySelectedCharacterVM.FallBack();
 				_previouslySelectedCharacterVM.IsSelected = false;
-				_officerCharacterWaitingForValidationVM = null;
+				_officerCharacterWaitingForValidationVM = null;				
 				SelectedCharacterVM = null;
 			}
 		}

--- a/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
@@ -134,7 +134,7 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
             if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new FormationControlMessage(missionPeer.GetNetworkPeer(), teamIndex, formationClass, false));
+                GameNetwork.WriteMessage(new FormationControlMessage(missionPeer.GetNetworkPeer(), teamIndex, formationClass, true));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
         }
@@ -172,17 +172,19 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         }
 
         public List<FormationClass> GetControlledFormations(MissionPeer missionPeer)
-        {            
-            if(missionPeer.Team == null) return new List<FormationClass>();
+		{
+			List<FormationClass> controlledFormations = new();
 
-			playerFormationMapping.TryGetValue(missionPeer.Team.TeamIndex, out var formationMapping);
+			if (missionPeer.Team == null) return controlledFormations;
 
-            List<FormationClass> controlledFormations = new();
-			foreach (KeyValuePair<FormationClass, MissionPeer> kvp in formationMapping)
-			{
-				if (kvp.Value == missionPeer)
+			if(playerFormationMapping.TryGetValue(missionPeer.Team.TeamIndex, out var formationMapping))
+            {
+				foreach (KeyValuePair<FormationClass, MissionPeer> kvp in formationMapping)
 				{
-					controlledFormations.Add(kvp.Key);
+					if (kvp.Value == missionPeer)
+					{
+						controlledFormations.Add(kvp.Key);
+					}
 				}
 			}
 

--- a/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
@@ -29,7 +29,7 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         private static readonly FormationControlModel instance = new();
         public static FormationControlModel Instance { get { return instance; } }
 
-        public event Action FormationControlChanged;
+        public event Action<FormationClass, Team, MissionPeer> FormationControlChanged;
         private readonly Dictionary<PlayerTeamKey, List<FormationClass>> playerFormationMapping = new();
 
         public FormationControlModel()
@@ -76,9 +76,9 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         /// Give control of a formation to a player.
         /// </summary>
         /// <param name="sync">Set this to true if you want to synchronize with all clients</param>
-        public void AssignControlToPlayer(MissionPeer missionPeer, FormationClass formationClass, bool sync = false)
+        public void AssignControlToPlayer(MissionPeer missionPeer, Team team, FormationClass formationClass, bool sync = false)
         {
-            PlayerTeamKey key = new PlayerTeamKey(missionPeer, missionPeer.Team);
+            PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
 
             if (!playerFormationMapping.ContainsKey(key))
             {
@@ -92,27 +92,24 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
                     // Check if another player already control this formation
                     foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
                     {
-                        if (kvp.Value.Contains(formationClass))
+                        if (kvp.Value.Contains(formationClass) && kvp.Key.Team == team)
                         {
-                            if (kvp.Key.Team == missionPeer.Team)
-                            {
-                                RemoveControlFromPlayer(kvp.Key.MissionPeer, formationClass, true);
-                            }
+                            RemoveControlFromPlayer(kvp.Key.MissionPeer, kvp.Key.Team, formationClass, true);
                         }
                     }
                 }
 
                 playerFormationMapping[key].Add(formationClass);
                 if (GameNetwork.IsServer) missionPeer.ControlledAgent?.Team.AssignPlayerAsSergeantOfFormation(key.MissionPeer, formationClass);
-                FormationControlChanged?.Invoke();
+                FormationControlChanged?.Invoke(formationClass, key.Team, key.MissionPeer);
 
-                Log($"Assigned {key.MissionPeer.Name} control over formation {formationClass}", LogLevel.Debug);
+                Log($"Assigned {key.MissionPeer.Name} control over {team.Side} formation {formationClass}", LogLevel.Debug);
             }
 
             if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), formationClass));
+                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), key.Team.TeamIndex, formationClass));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
         }
@@ -121,9 +118,9 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         /// Remove control of a formation from a player.
         /// </summary>
         /// <param name="sync">Set this to true if you want to synchronize with all clients</param>
-        public void RemoveControlFromPlayer(MissionPeer missionPeer, FormationClass formationClass, bool sync = false)
+        public void RemoveControlFromPlayer(MissionPeer missionPeer, Team team, FormationClass formationClass, bool sync = false)
         {
-            PlayerTeamKey key = new PlayerTeamKey(missionPeer, missionPeer.Team);
+            PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
 
             if (playerFormationMapping.TryGetValue(key, out var controlledFormations))
             {
@@ -131,7 +128,7 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
                 {
                     controlledFormations.Remove(formationClass);
                     if (GameNetwork.IsServer) key.MissionPeer.ControlledFormation = null;
-                    FormationControlChanged?.Invoke();
+                    FormationControlChanged?.Invoke(formationClass, key.Team, GetControllerOfFormation(formationClass, key.Team));
                 }
 
                 if (controlledFormations.Count == 0)
@@ -139,21 +136,36 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
                     playerFormationMapping.Remove(key);
                 }
 
-                Log($"Removed {key.MissionPeer.Name} control over formation {formationClass}", LogLevel.Debug);
+                Log($"Removed {key.MissionPeer.Name} control over {team.Side} formation {formationClass}", LogLevel.Debug);
             }
 
             if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), formationClass, false));
+                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), key.Team.TeamIndex, formationClass, false));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
         }
 
-        public void TransferControl(MissionPeer fromPeer, MissionPeer toPeer, FormationClass formationClass, bool sync = false)
+        public void RemoveAllControlFromPlayer(MissionPeer missionPeer, bool sync = false)
+		{
+            foreach(Team team in Mission.Current.Teams)
+            {
+				PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
+				if (playerFormationMapping.TryGetValue(key, out var controlledFormations))
+				{
+					foreach (FormationClass formationClass in new List<FormationClass>(controlledFormations))
+					{
+						RemoveControlFromPlayer(missionPeer, team, formationClass, sync);
+					}
+				}
+			}
+		}
+
+		public void TransferControl(MissionPeer fromPeer, MissionPeer toPeer, FormationClass formationClass, bool sync = false)
         {
-            RemoveControlFromPlayer(fromPeer, formationClass, sync);
-            AssignControlToPlayer(toPeer, formationClass, sync);
+            RemoveControlFromPlayer(fromPeer, toPeer.Team, formationClass, sync);
+            AssignControlToPlayer(toPeer, toPeer.Team, formationClass, sync);
         }
 
         public void SendMappingToClient(NetworkCommunicator peer)
@@ -167,7 +179,7 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
                     foreach (FormationClass formationClass in kvp.Value)
                     {
                         GameNetwork.BeginModuleEventAsServer(peer);
-                        GameNetwork.WriteMessage(new FormationControlMessage(peer, formationClass));
+                        GameNetwork.WriteMessage(new FormationControlMessage(kvp.Key.MissionPeer.GetNetworkPeer(), kvp.Key.Team.TeamIndex, formationClass));
                         GameNetwork.EndModuleEventAsServer();
                     }
                 }

--- a/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
@@ -14,25 +14,13 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
     /// </summary>
     public class FormationControlModel
     {
-        public struct PlayerTeamKey
-        {
-            public MissionPeer MissionPeer;
-            public Team Team;
-
-            public PlayerTeamKey(MissionPeer missionPeer, Team team)
-            {
-                MissionPeer = missionPeer;
-                Team = team;
-            }
-        }
-
         private static readonly FormationControlModel instance = new();
         public static FormationControlModel Instance { get { return instance; } }
 
-        public event Action<FormationClass, Team, MissionPeer> FormationControlChanged;
-        private readonly Dictionary<PlayerTeamKey, List<FormationClass>> playerFormationMapping = new();
+        public event Action<int, FormationClass, MissionPeer> FormationControlChanged;
+		private readonly Dictionary<int, Dictionary<FormationClass, MissionPeer>> playerFormationMapping = new();
 
-        public FormationControlModel()
+		public FormationControlModel()
         {
         }
 
@@ -45,11 +33,11 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         /// <summary>
         /// Request to assign control of a formation to a player.
         /// </summary>
-        public void RequestAssignControlToPlayer(MissionPeer missionPeer, FormationClass formationClass)
+        public void RequestAssignControlToPlayer(MissionPeer missionPeer, int formationIndex)
         {
-            Log($"Request assign control of {formationClass} to {missionPeer.Name}", LogLevel.Debug);
+            Log($"Request assign control of formation {formationIndex} to {missionPeer.Name}", LogLevel.Debug);
             GameNetwork.BeginModuleEventAsClient();
-            GameNetwork.WriteMessage(new FormationRequestControlMessage(missionPeer.GetNetworkPeer(), formationClass));
+            GameNetwork.WriteMessage(new FormationRequestControlMessage(missionPeer.GetNetworkPeer(), formationIndex));
             GameNetwork.EndModuleEventAsClient();
         }
 
@@ -60,56 +48,48 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         {
             if (agent.MissionPeer == null) return;
 
-            MissionPeer player = agent.MissionPeer;
-            PlayerTeamKey key = new PlayerTeamKey(player, player.Team);
-
-            if (playerFormationMapping.TryGetValue(key, out List<FormationClass> controlledFormations))
-            {
-                foreach (FormationClass controlledFormation in controlledFormations)
-                {
-                    agent.Team.AssignPlayerAsSergeantOfFormation(player, controlledFormation);
-                }
-            }
+            if(playerFormationMapping.TryGetValue(agent.Team.TeamIndex, out var formationMapping))
+			{
+				foreach (KeyValuePair<FormationClass, MissionPeer> kvp in formationMapping)
+				{
+					if (kvp.Value == agent.MissionPeer)
+					{
+						agent.Team.AssignPlayerAsSergeantOfFormation(agent.MissionPeer, kvp.Key);
+					}
+				}
+			}
         }
 
         /// <summary>
         /// Give control of a formation to a player.
         /// </summary>
         /// <param name="sync">Set this to true if you want to synchronize with all clients</param>
-        public void AssignControlToPlayer(MissionPeer missionPeer, Team team, FormationClass formationClass, bool sync = false)
+        public void AssignControlToPlayer(MissionPeer missionPeer, int teamIndex, FormationClass formationClass, bool sync = false)
         {
-            PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
-
-            if (!playerFormationMapping.ContainsKey(key))
+            if (!playerFormationMapping.TryGetValue(teamIndex, out var formationMapping))
             {
-                playerFormationMapping[key] = new List<FormationClass>();
+                playerFormationMapping[teamIndex] = new Dictionary<FormationClass, MissionPeer>();
             }
+			
+            // Remove control from any other player controlling this formation
+            if (formationMapping.TryGetValue(formationClass, out MissionPeer currentController))
+			{
+				if (currentController != missionPeer)
+				{
+					RemoveControlFromPlayer(currentController, teamIndex, formationClass, true);
+				}
+			}
 
-            if (!playerFormationMapping[key].Contains(formationClass))
-            {
-                if (sync)
-                {
-                    // Check if another player already control this formation
-                    foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
-                    {
-                        if (kvp.Value.Contains(formationClass) && kvp.Key.Team == team)
-                        {
-                            RemoveControlFromPlayer(kvp.Key.MissionPeer, kvp.Key.Team, formationClass, true);
-                        }
-                    }
-                }
-
-                playerFormationMapping[key].Add(formationClass);
-                if (GameNetwork.IsServer) missionPeer.ControlledAgent?.Team.AssignPlayerAsSergeantOfFormation(key.MissionPeer, formationClass);
-                FormationControlChanged?.Invoke(formationClass, key.Team, key.MissionPeer);
-
-                Log($"Assigned {key.MissionPeer.Name} control over {team.Side} formation {formationClass}", LogLevel.Debug);
-            }
+			// Assign control to the new player
+			formationMapping[formationClass] = missionPeer;
+            if (GameNetwork.IsServer) missionPeer.ControlledAgent?.Team.AssignPlayerAsSergeantOfFormation(missionPeer, formationClass);
+            FormationControlChanged?.Invoke(teamIndex, formationClass, missionPeer);
+            Log($"Assigned {missionPeer.Name} control over team {teamIndex} formation {formationClass}", LogLevel.Debug);
 
             if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), key.Team.TeamIndex, formationClass));
+                GameNetwork.WriteMessage(new FormationControlMessage(missionPeer.GetNetworkPeer(), teamIndex, formationClass));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
         }
@@ -118,45 +98,40 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         /// Remove control of a formation from a player.
         /// </summary>
         /// <param name="sync">Set this to true if you want to synchronize with all clients</param>
-        public void RemoveControlFromPlayer(MissionPeer missionPeer, Team team, FormationClass formationClass, bool sync = false)
+        public void RemoveControlFromPlayer(MissionPeer missionPeer, int teamIndex, FormationClass formationClass, bool sync = false)
         {
-            PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
-
-            if (playerFormationMapping.TryGetValue(key, out var controlledFormations))
+            if (playerFormationMapping.TryGetValue(teamIndex, out var formationMapping))
             {
-                if (controlledFormations.Contains(formationClass))
+                if(formationMapping.TryGetValue(formationClass, out MissionPeer controller))
                 {
-                    controlledFormations.Remove(formationClass);
-                    if (GameNetwork.IsServer) key.MissionPeer.ControlledFormation = null;
-                    FormationControlChanged?.Invoke(formationClass, key.Team, GetControllerOfFormation(formationClass, key.Team));
-                }
+					if (controller == missionPeer)
+					{
+                        formationMapping[formationClass] = null;
+                        if(GameNetwork.IsServer) missionPeer.ControlledFormation = null;
+                        FormationControlChanged?.Invoke(teamIndex, formationClass, null);
+					}
+				}
 
-                if (controlledFormations.Count == 0)
-                {
-                    playerFormationMapping.Remove(key);
-                }
-
-                Log($"Removed {key.MissionPeer.Name} control over {team.Side} formation {formationClass}", LogLevel.Debug);
+                Log($"Removed {missionPeer.Name} control over team {teamIndex} formation {formationClass}", LogLevel.Debug);
             }
 
             if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
-                GameNetwork.WriteMessage(new FormationControlMessage(key.MissionPeer.GetNetworkPeer(), key.Team.TeamIndex, formationClass, false));
+                GameNetwork.WriteMessage(new FormationControlMessage(missionPeer.GetNetworkPeer(), teamIndex, formationClass, false));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
         }
 
         public void RemoveAllControlFromPlayer(MissionPeer missionPeer, bool sync = false)
 		{
-            foreach(Team team in Mission.Current.Teams)
-            {
-				PlayerTeamKey key = new PlayerTeamKey(missionPeer, team);
-				if (playerFormationMapping.TryGetValue(key, out var controlledFormations))
+            foreach(KeyValuePair<int, Dictionary<FormationClass, MissionPeer>> teamMap in playerFormationMapping)
+			{
+				foreach (KeyValuePair<FormationClass, MissionPeer> formationMap in teamMap.Value)
 				{
-					foreach (FormationClass formationClass in new List<FormationClass>(controlledFormations))
+					if (formationMap.Value == missionPeer)
 					{
-						RemoveControlFromPlayer(missionPeer, team, formationClass, sync);
+						RemoveControlFromPlayer(missionPeer, teamMap.Key, formationMap.Key, sync);
 					}
 				}
 			}
@@ -164,76 +139,71 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
 
 		public void TransferControl(MissionPeer fromPeer, MissionPeer toPeer, FormationClass formationClass, bool sync = false)
         {
-            RemoveControlFromPlayer(fromPeer, toPeer.Team, formationClass, sync);
-            AssignControlToPlayer(toPeer, toPeer.Team, formationClass, sync);
+            RemoveControlFromPlayer(fromPeer, toPeer.Team.TeamIndex, formationClass, sync);
+            AssignControlToPlayer(toPeer, toPeer.Team.TeamIndex, formationClass, sync);
         }
 
         public void SendMappingToClient(NetworkCommunicator peer)
         {
             Log($"Sending formation mapping info to {peer.UserName}. Commanders : {playerFormationMapping.Count}", LogLevel.Debug);
 
-            foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
-            {
-                if (kvp.Key.MissionPeer != null)
-                {
-                    foreach (FormationClass formationClass in kvp.Value)
-                    {
-                        GameNetwork.BeginModuleEventAsServer(peer);
-                        GameNetwork.WriteMessage(new FormationControlMessage(kvp.Key.MissionPeer.GetNetworkPeer(), kvp.Key.Team.TeamIndex, formationClass));
-                        GameNetwork.EndModuleEventAsServer();
-                    }
-                }
-            }
+			foreach (KeyValuePair<int, Dictionary<FormationClass, MissionPeer>> teamMap in playerFormationMapping)
+			{
+				foreach (KeyValuePair<FormationClass, MissionPeer> formationMap in teamMap.Value)
+				{
+					if (formationMap.Value != null)
+					{
+						GameNetwork.BeginModuleEventAsServer(peer);
+						GameNetwork.WriteMessage(new FormationControlMessage(formationMap.Value.GetNetworkPeer(), teamMap.Key, formationMap.Key));
+						GameNetwork.EndModuleEventAsServer();
+					}
+				}
+			}
         }
 
         public List<FormationClass> GetControlledFormations(MissionPeer missionPeer)
-        {
-            PlayerTeamKey key = new PlayerTeamKey(missionPeer, missionPeer.Team);
+        {            
+            if(missionPeer.Team == null) return new List<FormationClass>();
 
-            if (playerFormationMapping.TryGetValue(key, out var controlledFormations))
-            {
-                return controlledFormations;
-            }
-            return new List<FormationClass>();
-        }
+			playerFormationMapping.TryGetValue(missionPeer.Team.TeamIndex, out var formationMapping);
 
-        public List<string> GetAllControllersNameFromTeam(Team team)
-        {
-            List<string> controllers = new();
+            List<FormationClass> controlledFormations = new();
+			foreach (KeyValuePair<FormationClass, MissionPeer> kvp in formationMapping)
+			{
+				if (kvp.Value == missionPeer)
+				{
+					controlledFormations.Add(kvp.Key);
+				}
+			}
 
-            foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
-            {
-                if (kvp.Key.Team == team)
-                {
-                    controllers.Add(kvp.Key.MissionPeer.Name);
-                }
-            }
-
-            return controllers;
+			return controlledFormations;
         }
 
         public List<MissionPeer> GetAllControllersFromTeam(Team team)
         {
             List<MissionPeer> controllers = new();
 
-            foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
-            {
-                if (kvp.Key.Team == team)
-                {
-                    controllers.Add(kvp.Key.MissionPeer);
-                }
-            }
-
+            if(playerFormationMapping.TryGetValue(team.TeamIndex, out var formationMapping))
+			{
+				foreach (KeyValuePair<FormationClass, MissionPeer> kvp in formationMapping)
+				{
+					if (kvp.Value != null && !controllers.Contains(kvp.Value))
+					{
+						controllers.Add(kvp.Value);
+					}
+				}
+			}
+            
             return controllers;
         }
 
         public MissionPeer GetControllerOfFormation(FormationClass i, Team team)
         {
-            foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
+            if(playerFormationMapping.TryGetValue(team.TeamIndex, out var formationMapping))
             {
-                if (kvp.Key.Team == team && kvp.Value.Contains(i))
+                if (formationMapping.TryGetValue(i, out var controller))
                 {
-                    return kvp.Key.MissionPeer;
+                    return controller;
                 }
             }
 
@@ -242,29 +212,20 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
 
         public MissionPeer GetControllerOfFormation(Formation formation)
         {
-            foreach (KeyValuePair<PlayerTeamKey, List<FormationClass>> kvp in playerFormationMapping)
-            {
-                if (kvp.Key.Team == formation.Team && kvp.Value.Contains(formation.FormationIndex))
-                {
-                    return kvp.Key.MissionPeer;
-                }
-            }
+			if (playerFormationMapping.TryGetValue(formation.Team.TeamIndex, out var formationMapping))
+			{
+				if (formationMapping.TryGetValue(formation.FormationIndex, out var controller))
+				{
+					return controller;
+				}
+			}
 
-            return null;
-        }
+			return null;
+		}
 
         public bool IsPlayerControllingAgent(MissionPeer player, Agent followedAgent)
         {
-            PlayerTeamKey key = new PlayerTeamKey(player, player.Team);
-            bool isPlayerControllingAgent = false;
-            if (player.Team == followedAgent.Team && playerFormationMapping.TryGetValue(key, out List<FormationClass> controlledForms))
-            {
-                if (controlledForms.Contains(followedAgent.Formation.FormationIndex))
-                {
-                    isPlayerControllingAgent = true;
-                }
-            }
-            return isPlayerControllingAgent;
+            return GetControllerOfFormation(followedAgent.Formation) == player;
         }
     }
 }

--- a/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
@@ -24,17 +24,6 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         {
         }
 
-        public void DebugLog()
-        {
-            foreach(KeyValuePair<int, Dictionary<FormationClass, MissionPeer>> teamMap in playerFormationMapping)
-			{
-				foreach (KeyValuePair<FormationClass, MissionPeer> formationMap in teamMap.Value)
-				{
-					Log($"-Team {teamMap.Key} Formation {formationMap.Key} controlled by {formationMap.Value?.Name}", LogLevel.Debug);
-				}
-			}
-        }
-
         public void Clear()
         {
             playerFormationMapping.Clear();
@@ -97,8 +86,6 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
             if (GameNetwork.IsServer) missionPeer.ControlledAgent?.Team.AssignPlayerAsSergeantOfFormation(missionPeer, formationClass);
             FormationControlChanged?.Invoke(teamIndex, formationClass, missionPeer);
             Log($"Assigned {missionPeer.Name} control over team {teamIndex} formation {formationClass}", LogLevel.Debug);
-
-			DebugLog();
 
 			if (sync)
             {

--- a/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/Models/FormationControlModel.cs
@@ -24,6 +24,17 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         {
         }
 
+        public void DebugLog()
+        {
+            foreach(KeyValuePair<int, Dictionary<FormationClass, MissionPeer>> teamMap in playerFormationMapping)
+			{
+				foreach (KeyValuePair<FormationClass, MissionPeer> formationMap in teamMap.Value)
+				{
+					Log($"-Team {teamMap.Key} Formation {formationMap.Key} controlled by {formationMap.Value?.Name}", LogLevel.Debug);
+				}
+			}
+        }
+
         public void Clear()
         {
             playerFormationMapping.Clear();
@@ -69,7 +80,8 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
             if (!playerFormationMapping.TryGetValue(teamIndex, out var formationMapping))
             {
                 playerFormationMapping[teamIndex] = new Dictionary<FormationClass, MissionPeer>();
-            }
+				formationMapping = playerFormationMapping[teamIndex];
+			}
 			
             // Remove control from any other player controlling this formation
             if (formationMapping.TryGetValue(formationClass, out MissionPeer currentController))
@@ -86,7 +98,9 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
             FormationControlChanged?.Invoke(teamIndex, formationClass, missionPeer);
             Log($"Assigned {missionPeer.Name} control over team {teamIndex} formation {formationClass}", LogLevel.Debug);
 
-            if (sync)
+			DebugLog();
+
+			if (sync)
             {
                 GameNetwork.BeginBroadcastModuleEvent();
                 GameNetwork.WriteMessage(new FormationControlMessage(missionPeer.GetNetworkPeer(), teamIndex, formationClass));
@@ -100,7 +114,9 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
         /// <param name="sync">Set this to true if you want to synchronize with all clients</param>
         public void RemoveControlFromPlayer(MissionPeer missionPeer, int teamIndex, FormationClass formationClass, bool sync = false)
         {
-            if (playerFormationMapping.TryGetValue(teamIndex, out var formationMapping))
+            if(missionPeer == null) return;
+
+			if (playerFormationMapping.TryGetValue(teamIndex, out var formationMapping))
             {
                 if(formationMapping.TryGetValue(formationClass, out MissionPeer controller))
                 {
@@ -136,12 +152,6 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
 				}
 			}
 		}
-
-		public void TransferControl(MissionPeer fromPeer, MissionPeer toPeer, FormationClass formationClass, bool sync = false)
-        {
-            RemoveControlFromPlayer(fromPeer, toPeer.Team.TeamIndex, formationClass, sync);
-            AssignControlToPlayer(toPeer, toPeer.Team.TeamIndex, formationClass, sync);
-        }
 
         public void SendMappingToClient(NetworkCommunicator peer)
         {
@@ -212,6 +222,8 @@ namespace Alliance.Common.Extensions.TroopSpawner.Models
 
         public MissionPeer GetControllerOfFormation(Formation formation)
         {
+            if(formation.Team == null) return null;
+
 			if (playerFormationMapping.TryGetValue(formation.Team.TeamIndex, out var formationMapping))
 			{
 				if (formationMapping.TryGetValue(formation.FormationIndex, out var controller))

--- a/Alliance.Common/Extensions/TroopSpawner/NetworkMessages/FromClient/FormationRequestControlMessage.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/NetworkMessages/FromClient/FormationRequestControlMessage.cs
@@ -11,11 +11,11 @@ namespace Alliance.Common.Extensions.TroopSpawner.NetworkMessages.FromClient
     public sealed class FormationRequestControlMessage : GameNetworkMessage
     {
         public NetworkCommunicator Peer { get; private set; }
-        public FormationClass Formation { get; private set; }
+        public int Formation { get; private set; }
 
         public FormationRequestControlMessage() { }
 
-        public FormationRequestControlMessage(NetworkCommunicator peer, FormationClass formation)
+        public FormationRequestControlMessage(NetworkCommunicator peer, int formation)
         {
             Peer = peer;
             Formation = formation;
@@ -24,14 +24,14 @@ namespace Alliance.Common.Extensions.TroopSpawner.NetworkMessages.FromClient
         protected override void OnWrite()
         {
             WriteNetworkPeerReferenceToPacket(Peer);
-            WriteIntToPacket((int)Formation, CompressionMission.FormationClassCompressionInfo);
+            WriteIntToPacket(Formation, CompressionMission.FormationClassCompressionInfo);
         }
 
-        protected override bool OnRead()
+        protected override bool OnRead()    
         {
             bool bufferReadValid = true;
             Peer = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-            Formation = (FormationClass)ReadIntFromPacket(CompressionMission.FormationClassCompressionInfo, ref bufferReadValid);
+            Formation = ReadIntFromPacket(CompressionMission.FormationClassCompressionInfo, ref bufferReadValid);
             return bufferReadValid;
         }
 

--- a/Alliance.Common/Extensions/TroopSpawner/NetworkMessages/FromServer/FormationControlMessage.cs
+++ b/Alliance.Common/Extensions/TroopSpawner/NetworkMessages/FromServer/FormationControlMessage.cs
@@ -1,4 +1,5 @@
-﻿using TaleWorlds.Core;
+﻿using NetworkMessages.FromServer;
+using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
 
@@ -11,14 +12,16 @@ namespace Alliance.Common.Extensions.TroopSpawner.NetworkMessages.FromServer
     public sealed class FormationControlMessage : GameNetworkMessage
     {
         public NetworkCommunicator Peer { get; private set; }
-        public FormationClass Formation { get; private set; }
+        public int TeamIndex { get; private set; }
+		public FormationClass Formation { get; private set; }
         public bool Delete { get; private set; }
 
         public FormationControlMessage() { }
 
-        public FormationControlMessage(NetworkCommunicator peer, FormationClass formation, bool delete = false)
+        public FormationControlMessage(NetworkCommunicator peer, int teamIndex, FormationClass formation, bool delete = false)
         {
             Peer = peer;
+            TeamIndex = teamIndex;
             Formation = formation;
             Delete = delete;
         }
@@ -26,6 +29,7 @@ namespace Alliance.Common.Extensions.TroopSpawner.NetworkMessages.FromServer
         protected override void OnWrite()
         {
             WriteNetworkPeerReferenceToPacket(Peer);
+            WriteTeamIndexToPacket(TeamIndex);
             WriteIntToPacket((int)Formation, CompressionMission.FormationClassCompressionInfo);
             WriteBoolToPacket(Delete);
         }
@@ -34,7 +38,8 @@ namespace Alliance.Common.Extensions.TroopSpawner.NetworkMessages.FromServer
         {
             bool bufferReadValid = true;
             Peer = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-            Formation = (FormationClass)ReadIntFromPacket(CompressionMission.FormationClassCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadTeamIndexFromPacket(ref bufferReadValid);
+			Formation = (FormationClass)ReadIntFromPacket(CompressionMission.FormationClassCompressionInfo, ref bufferReadValid);
             Delete = ReadBoolFromPacket(ref bufferReadValid);
             return bufferReadValid;
         }

--- a/Alliance.Common/_Module/AssetPackages/ui_kingdom_1_tex.tpac
+++ b/Alliance.Common/_Module/AssetPackages/ui_kingdom_1_tex.tpac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54bd12b916e2f192a9b93b6c876b04c7eb3121d92a9f17d1487a0017d76f92f0
+size 10980806

--- a/Alliance.Common/_Module/GUI/Prefabs/ClassLoadout/MultiplayerClassLoadoutPerkPopup.xml
+++ b/Alliance.Common/_Module/GUI/Prefabs/ClassLoadout/MultiplayerClassLoadoutPerkPopup.xml
@@ -1,50 +1,68 @@
 <Prefab>
-  <Constants>
-    <Constant Name="Perks.Frame.Width" BrushLayer="Default" BrushName="MPClassLoadout.Perks.Frame" BrushValueType="Width" />
-    <Constant Name="Perks.Frame.Height" BrushLayer="Default" BrushName="MPClassLoadout.Perks.Frame" BrushValueType="Height" />
-    <Constant Name="Perks.Name.Width" Additive="10" Value="!Perks.Frame.Width" />
-  </Constants>
-  <Parameters>
-    <Parameter Name="DataSource" DefaultValue="" />
-  </Parameters>
-  <Window>
-    <MultiplayerPerkPopupWidget DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Sprite="perks_popup_bg_9" IsVisible="false">
-      <Children>
-        <NavigationForcedScopeCollectionTargeter CollectionID="PerkPopupCollection" CollectionParent="..\." />
-        <NavigationScopeTargeter ScopeID="PerkPopupScope" ScopeParent="..\Perks" ScopeMovements="Horizontal"/>
-        <NavigatableListPanel Id="Perks" DataSource="*DataSource" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" MarginTop="15" MarginBottom="15" MarginLeft="15" MarginRight="15">
-          <ItemTemplate>
-            <Widget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren">
-              <Children>
+	<Constants>
+		<Constant Name="Perks.Frame.Width" BrushLayer="Default" BrushName="MPClassLoadout.Perks.Frame" BrushValueType="Width" />
+		<Constant Name="Perks.Frame.Height" BrushLayer="Default" BrushName="MPClassLoadout.Perks.Frame" BrushValueType="Height" />
+		<Constant Name="Perks.Name.Width" Additive="10" Value="!Perks.Frame.Width" />
+	</Constants>
+	<Parameters>
+		<Parameter Name="DataSource" DefaultValue="" />
+	</Parameters>
+	<Window>
+		<MultiplayerPerkPopupWidget DoNotAcceptEvents="false" WidthSizePolicy="CoverChildren" MaxWidth="560" HeightSizePolicy="Fixed" SuggestedHeight="145" Sprite="perks_popup_bg_9" IsVisible="false">
+			<Children>
+				<NavigationForcedScopeCollectionTargeter CollectionID="PerkPopupCollection" CollectionParent="..\." />
+				<ScrollablePanel Id="PerksScrollablePanel" WidthSizePolicy="CoverChildren" MaxWidth="500" HeightSizePolicy="Fixed" SuggestedHeight="115" HorizontalAlignment="Center" VerticalAlignment="Top" AutoHideScrollBars="true" HorizontalScrollbar="..\PerksScrollbarContainer\PerksScrollbar" InnerPanel="PerksClipRect\Perks" ClipRect="PerksClipRect" MarginTop="15" MarginLeft="15" MarginRight="15">
+					<Children>
+						<Widget Id="PerksClipRect" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
+							<Children>
+								<NavigationScopeTargeter ScopeID="PerkPopupScope" ScopeParent="..\Perks" ScopeMovements="Horizontal"/>
+								<NavigatableListPanel Id="Perks" DataSource="*DataSource" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+									<ItemTemplate>
+										<Widget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren">
+											<Children>
 
-                <MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="CoverChildren" MinWidth="150" HeightSizePolicy="Fixed" SuggestedHeight="115" Command.Click="ExecuteSelectPerk" IconType="@IconType" IconWidget="Placement\Icon" IsEnabled="@IsSelectable" UpdateChildrenStates="true" Brush="MPClassLoadout.Perks.Button">
-                  <Children>
+												<MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="CoverChildren" MinWidth="150" HeightSizePolicy="Fixed" SuggestedHeight="115" Command.Click="ExecuteSelectPerk" IconType="@IconType" IconWidget="Placement\Icon" IsEnabled="@IsSelectable" UpdateChildrenStates="true" Brush="MPClassLoadout.Perks.Button">
+													<Children>
 
-                    <ListPanel Id="Placement" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" StackLayout.LayoutMethod="VerticalTopToBottom" UpdateChildrenStates="true" MarginTop="25" MarginBottom="15" MarginLeft="10" MarginRight="10" >
-                      <Children>
-                        <BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.PopupIcon" UpdateChildrenStates="true">
-                          <Children>
-                            <BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
-                          </Children>
-                        </BrushWidget>
-                        <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="150" HorizontalAlignment="Center" VerticalAlignment="Top" MarginTop="5" Brush="MPClassLoadout.PerkPopup.NameText" ClipContents="false" Text="@Name" />
-                      </Children>
-                    </ListPanel>
+														<ListPanel Id="Placement" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" StackLayout.LayoutMethod="VerticalTopToBottom" UpdateChildrenStates="true" MarginTop="25" MarginBottom="15" MarginLeft="10" MarginRight="10" >
+															<Children>
+																<BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.PopupIcon" UpdateChildrenStates="true">
+																	<Children>
+																		<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
+																	</Children>
+																</BrushWidget>
+																<TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="150" HorizontalAlignment="Center" VerticalAlignment="Top" MarginTop="5" Brush="MPClassLoadout.PerkPopup.NameText" ClipContents="false" Text="@Name" />
+															</Children>
+														</ListPanel>
 
-                    <HintWidget Id="Hint" DataSource="{Hint}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" HorizontalAlignment="Center" />
-                  
-                  </Children>
-                </MultiplayerPerkItemToggleWidget>
+														<HintWidget Id="Hint" DataSource="{Hint}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" HorizontalAlignment="Center" />
 
-                <HintWidget Id="Hint" DataSource="{Hint}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" HorizontalAlignment="Center" />
+													</Children>
+												</MultiplayerPerkItemToggleWidget>
 
-              </Children>
-            </Widget>
+												<HintWidget Id="Hint" DataSource="{Hint}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" HorizontalAlignment="Center" />
 
-          </ItemTemplate>
-        </NavigatableListPanel>
-      </Children>
-    </MultiplayerPerkPopupWidget>
-  
-</Window>
+											</Children>
+										</Widget>
+
+									</ItemTemplate>
+								</NavigatableListPanel>
+							</Children>
+						</Widget>
+					</Children>
+				</ScrollablePanel>
+				<Widget Id="PerksScrollbarContainer" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="8" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="4">
+					<Children>
+						<ScrollbarWidget Id="PerksScrollbar" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" AlignmentAxis="Horizontal" Handle="PerksScrollbarHandle" MaxValue="100" MinValue="0" UpdateChildrenStates="true">
+							<Children>
+								<Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="8" HorizontalAlignment="Center" Sprite="lobby_slider_bed_9" AlphaFactor="0.1" />
+								<ImageWidget Id="PerksScrollbarHandle" WidthSizePolicy="Fixed" SuggestedWidth="20" HeightSizePolicy="Fixed" SuggestedHeight="8" HorizontalAlignment="Center" Brush="MPLobby.CustomServer.ScrollHandle" MinWidth="40" />
+							</Children>
+						</ScrollbarWidget>
+					</Children>
+				</Widget>
+			</Children>
+		</MultiplayerPerkPopupWidget>
+
+	</Window>
 </Prefab>

--- a/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/CharacterItem.xml
+++ b/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/CharacterItem.xml
@@ -12,6 +12,7 @@
 								SuggestedHeight="580"
 								DoNotPassEventsToChildren="true"
 								UpdateChildrenStates="true"
+								IsSelected="@IsSelected"
 								Command.Click="SelectCharacter">
 					<Children>
 
@@ -121,23 +122,41 @@
 					<Children>
 
 						<!--Perks-->
-						<MultiplayerPerkContainerPanelWidget Id="PerksPanel" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" PositionXOffset="2" PopupWidgetFirst="..\..\..\..\..\..\FirstPerks" PopupWidgetSecond="..\..\..\..\..\..\SecondPerks" PopupWidgetThird="..\..\..\..\..\..\ThirdPerks" TroopTupleBodyWidget="..\..\CharacterButton" >
+						<MultiplayerPerkContainerPanelWidget Id="PerksPanel" WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="310" HorizontalAlignment="Center" PositionXOffset="2" PopupWidgetFirst="..\..\..\..\..\..\PerksContainer\FirstPerks" PopupWidgetSecond="..\..\..\..\..\..\PerksContainer\SecondPerks" PopupWidgetThird="..\..\..\..\..\..\PerksContainer\ThirdPerks" TroopTupleBodyWidget="..\..\CharacterButton" >
 							<Children>
-								<NavigationScopeTargeter Id="ScopeTargeter" ScopeID="ClassSelectionPerksScope" ScopeParent="..\Perks" ScopeMovements="Horizontal" />
-								<NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
-									<ItemTemplate>
-										<MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="80" HorizontalAlignment="Center" MarginLeft="5" Brush="MPClassLoadout.Perks.Button" ContainerPanel="..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
+								<ScrollablePanel Id="PerksScrollPanel" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="310" SuggestedHeight="120" HorizontalAlignment="Center" AutoHideScrollBars="true" HorizontalScrollbar="..\PerksScrollbarContainer\PerksScrollbar" InnerPanel="PerksClipRect\Perks" ClipRect="PerksClipRect">
+									<Children>
+										<Widget Id="PerksClipRect" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" ClipContents="true">
 											<Children>
-												<BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="18" Brush="MPClassLoadout.Perks.Icon" >
-													<Children>
-														<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
-													</Children>
-												</BrushWidget>
-												<TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="25" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="8" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
+												<NavigationScopeTargeter Id="ScopeTargeter" ScopeID="ClassSelectionPerksScope" ScopeParent="..\Perks" ScopeMovements="Horizontal" />
+												<NavigatableListPanel Id="Perks" DataSource="{Perks}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+													<ItemTemplate>
+														<MultiplayerPerkItemToggleWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="80" HorizontalAlignment="Center" MarginLeft="5" Brush="MPClassLoadout.Perks.Button" ContainerPanel="..\..\..\..\..\PerksPanel" IconType="@IconType" IconWidget="Icon" IsSelectable="true" UpdateChildrenStates="true">
+															<Children>
+																<BrushWidget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="40" SuggestedHeight="40" HorizontalAlignment="Center" MarginTop="18" Brush="MPClassLoadout.Perks.Icon" >
+																	<Children>
+																		<BrushWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="47" SuggestedHeight="47" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPClassLoadout.Perks.Frame" />
+																	</Children>
+																</BrushWidget>
+																<TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="25" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="8" MarginLeft="5" MarginRight="5" Brush="MPClassLoadout.PerkNameText" Brush.TextVerticalAlignment="Top" Text="@Name" />
+															</Children>
+														</MultiplayerPerkItemToggleWidget>
+													</ItemTemplate>
+												</NavigatableListPanel>
 											</Children>
-										</MultiplayerPerkItemToggleWidget>
-									</ItemTemplate>
-								</NavigatableListPanel>
+										</Widget>
+									</Children>
+								</ScrollablePanel>
+								<Widget Id="PerksScrollbarContainer" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="250" SuggestedHeight="4" HorizontalAlignment="Center" VerticalAlignment="Bottom" MarginBottom="2">
+									<Children>
+										<ScrollbarWidget Id="PerksScrollbar" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" AlignmentAxis="Horizontal" Handle="PerksScrollbarHandle" MaxValue="100" MinValue="0" UpdateChildrenStates="true">
+											<Children>
+												<Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="2" HorizontalAlignment="Center" Sprite="lobby_slider_bed_9" AlphaFactor="0.2" />
+												<ImageWidget Id="PerksScrollbarHandle" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="4" HorizontalAlignment="Center" Brush="MPLobby.CustomServer.ScrollHandle" MinWidth="40" />
+											</Children>
+										</ScrollbarWidget>
+									</Children>
+								</Widget>
 							</Children>
 						</MultiplayerPerkContainerPanelWidget>
 

--- a/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/CharacterItem.xml
+++ b/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/CharacterItem.xml
@@ -17,7 +17,7 @@
 					<Children>
 
 						<!-- Character Tableau -->
-						<AL_CharacterTableauWidget DataSource="{CharacterViewModel}"
+						<CharacterTableauWidget DataSource="{CharacterViewModel}"
 														WidthSizePolicy="Fixed"
 														HeightSizePolicy="Fixed"
 														SuggestedWidth="800"

--- a/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/PlayerSpawnMenu.xml
+++ b/Alliance.Common/_Module/GUI/Prefabs/PlayerSpawnMenu/PlayerSpawnMenu.xml
@@ -189,10 +189,13 @@
 				</BrushWidget>
 
 				<!-- Selected perks -->
-				<MultiplayerClassLoadoutPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\FirstPerk\CandidatePerks}" MarginTop="-280"/>
-				<MultiplayerClassLoadoutPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\SecondPerk\CandidatePerks}" MarginTop="-280"/>
-				<MultiplayerClassLoadoutPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\ThirdPerk\CandidatePerks}" MarginTop="-280"/>
-
+				<Widget Id="PerksContainer" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" HorizontalAlignment="Left" VerticalAlignment="Top" DoNotAcceptEvents="true" IsHidden="@ForceHidePerkPopups" >
+					<Children>
+						<MultiplayerClassLoadoutPerkPopup Id="FirstPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\FirstPerk\CandidatePerks}" MarginTop="-280" />
+						<MultiplayerClassLoadoutPerkPopup Id="SecondPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\SecondPerk\CandidatePerks}" MarginTop="-280" />
+						<MultiplayerClassLoadoutPerkPopup Id="ThirdPerks" IsEnabled="false" Parameter.DataSource="{SelectedCharacterVM\ThirdPerk\CandidatePerks}" MarginTop="-280" />
+					</Children>
+				</Widget>
 
 			</Children>
 		</BrushWidget>

--- a/Alliance.Editor/_Module/SubModule.xml
+++ b/Alliance.Editor/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance.Editor" />
   <Name value="Alliance.Editor" />
-  <Version value="v0.5.6.0" />
+  <Version value="v0.5.7.0" />
   <ModuleCategory value="Singleplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.SP/_Module/SubModule.xml
+++ b/Alliance.SP/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance.SP" />
   <Name value="Alliance.SP" />
-  <Version value="v0.5.6.0" />
+  <Version value="v0.5.7.0" />
   <ModuleCategory value="Singleplayer" />
   <DependedModules>
     <DependedModule Id="Native" />

--- a/Alliance.Server/Extensions/AIBehavior/Behaviors/ALGlobalAIBehavior.cs
+++ b/Alliance.Server/Extensions/AIBehavior/Behaviors/ALGlobalAIBehavior.cs
@@ -46,7 +46,7 @@ namespace Alliance.Server.Extensions.AIBehavior.Behaviors
 			Mission.Current.AllowAiTicking = false;
 			AddTeamAI(Mission.Current.AttackerTeam);
 			AddTeamAI(Mission.Current.DefenderTeam);
-			EnableAIAfterTimer(Config.Instance.TimeBeforeStart * 1000 + MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions));
+			EnableAIAfterTimer(1000 * MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue());
 		}
 
 		private async void EnableAIAfterTimer(int waitTime)

--- a/Alliance.Server/Extensions/TroopSpawner/Behaviors/TroopSpawnerBehavior.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Behaviors/TroopSpawnerBehavior.cs
@@ -62,6 +62,11 @@ namespace Alliance.Server.Extensions.TroopSpawner.Behaviors
 			FormationControlModel.Instance.SendMappingToClient(networkPeer);
 		}
 
+		protected override void HandleEarlyPlayerDisconnect(NetworkCommunicator networkPeer)
+		{
+			FormationControlModel.Instance.RemoveAllControlFromPlayer(networkPeer.GetComponent<MissionPeer>(), true);
+		}
+
 		public override void OnAgentBuild(Agent agent, Banner banner)
 		{
 			FormationControlModel.Instance.ReassignControlToAgent(agent);

--- a/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -40,7 +40,7 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 			MissionPeer commander = model.Peer.GetComponent<MissionPeer>();
 			if (commander == null) return false;
 
-			FormationControlModel.Instance.AssignControlToPlayer(commander, commander.Team, model.Formation, true);
+			FormationControlModel.Instance.AssignControlToPlayer(commander, commander.Team.TeamIndex, (FormationClass)model.Formation, true);
 			return true;
 		}
 
@@ -134,7 +134,8 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 				if (previousSergeant != missionPeer)
 				{
 					// Unassign previous sergeant from this formation to prevent crash 
-					FormationControlModel.Instance.TransferControl(previousSergeant, missionPeer, (FormationClass)model.Formation, true);
+					if(previousSergeant != null) FormationControlModel.Instance.RemoveControlFromPlayer(previousSergeant, missionPeer.Team.TeamIndex, (FormationClass)model.Formation, true);
+					FormationControlModel.Instance.AssignControlToPlayer(missionPeer, missionPeer.Team.TeamIndex, (FormationClass)model.Formation, true);
 				}
 			}
 

--- a/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -133,8 +133,6 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 
 				if (previousSergeant != missionPeer)
 				{
-					// Unassign previous sergeant from this formation to prevent crash 
-					if(previousSergeant != null) FormationControlModel.Instance.RemoveControlFromPlayer(previousSergeant, missionPeer.Team.TeamIndex, (FormationClass)model.Formation, true);
 					FormationControlModel.Instance.AssignControlToPlayer(missionPeer, missionPeer.Team.TeamIndex, (FormationClass)model.Formation, true);
 				}
 			}

--- a/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -257,7 +257,7 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 				return false;
 			}
 			// If player lacks gold
-			if (!model.SpawnAtExactPosition && isCommander && Config.Instance.UseTroopCost && goldRemaining < 0)
+			if (!model.SpawnAtExactPosition && Config.Instance.UseTroopCost && goldRemaining < 0)
 			{
 				refuseReason = "You need more gold.";
 				return false;

--- a/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
+++ b/Alliance.Server/Extensions/TroopSpawner/Handlers/SpawnTroopHandler.cs
@@ -40,7 +40,7 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 			MissionPeer commander = model.Peer.GetComponent<MissionPeer>();
 			if (commander == null) return false;
 
-			FormationControlModel.Instance.AssignControlToPlayer(commander, model.Formation, true);
+			FormationControlModel.Instance.AssignControlToPlayer(commander, commander.Team, model.Formation, true);
 			return true;
 		}
 
@@ -134,12 +134,7 @@ namespace Alliance.Server.Extensions.TroopSpawner.Handlers
 				if (previousSergeant != missionPeer)
 				{
 					// Unassign previous sergeant from this formation to prevent crash 
-					if (previousSergeant != null)
-					{
-						FormationControlModel.Instance.RemoveControlFromPlayer(previousSergeant, (FormationClass)model.Formation, true);
-						previousSergeant.ControlledFormation = null;
-					}
-					FormationControlModel.Instance.AssignControlToPlayer(missionPeer, (FormationClass)model.Formation, true);
+					FormationControlModel.Instance.TransferControl(previousSergeant, missionPeer, (FormationClass)model.Formation, true);
 				}
 			}
 

--- a/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
+++ b/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
@@ -229,12 +229,13 @@ namespace Alliance.Server.GameModes.CaptainX.Behaviors
 			}
 
 			// Make use of the warmup to let players elect their officers
-			if (WarmupComponent != null) _playerSpawnBehavior.StartElectionCountdown(MultiplayerOptions.OptionType.WarmupTimeLimitInSeconds.GetIntValue());
+			if (WarmupComponent != null) _playerSpawnBehavior.StartElectionCountdown(Config.Instance.ElectionTimer);
 		}
 
 		private void StartPlayerSpawnSession()
 		{
-			_playerSpawnBehavior.StartSpawnSession(MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue(), MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue());
+			float maxSpawnTime = Math.Max(MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue(), Config.Instance.FreeRespawnTimer);
+			_playerSpawnBehavior.StartSpawnSession(MultiplayerOptions.OptionType.RoundPreparationTimeLimit.GetIntValue(), maxSpawnTime);
 		}
 
 		protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)

--- a/Alliance.Server/GameModes/PvC/PvCGameMode.cs
+++ b/Alliance.Server/GameModes/PvC/PvCGameMode.cs
@@ -33,6 +33,7 @@ namespace Alliance.Server.GameModes.PvC
 
 				// Native captain behaviors
 				new MultiplayerRoundController(),
+				new MultiplayerWarmupComponent(),
 				new MultiplayerTeamSelectComponent(),
 				new MissionAgentPanicHandler(),
 				new AgentVictoryLogic()

--- a/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
@@ -76,7 +76,7 @@ namespace Alliance.Server.GameModes.Story.Actions
 
 				if (playerInCharge != null)
 				{
-					FormationControlModel.Instance.AssignControlToPlayer(playerInCharge, Formation, true);
+					FormationControlModel.Instance.AssignControlToPlayer(playerInCharge, team, Formation, true);
 				}
 				else
 				{

--- a/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_SpawnFormationAction.cs
@@ -76,7 +76,7 @@ namespace Alliance.Server.GameModes.Story.Actions
 
 				if (playerInCharge != null)
 				{
-					FormationControlModel.Instance.AssignControlToPlayer(playerInCharge, team, Formation, true);
+					FormationControlModel.Instance.AssignControlToPlayer(playerInCharge, team.TeamIndex, Formation, true);
 				}
 				else
 				{

--- a/Alliance.Server/Patch/HarmonyPatch/Patch_MissionNetworkComponent.cs
+++ b/Alliance.Server/Patch/HarmonyPatch/Patch_MissionNetworkComponent.cs
@@ -253,7 +253,7 @@ namespace Alliance.Server.Patch.HarmonyPatch
 
 			// Give control to player
 			Log($"Giving control of formation {formation.Index} to {networkPeer.UserName}", LogLevel.Information);
-			FormationControlModel.Instance.AssignControlToPlayer(networkPeer.GetComponent<MissionPeer>(), teamOfPeer, formation.FormationIndex, true);
+			FormationControlModel.Instance.AssignControlToPlayer(networkPeer.GetComponent<MissionPeer>(), teamOfPeer.TeamIndex, formation.FormationIndex, true);
 
 			int number = message.Number;
 			if (teamOfPeer != null && orderController != null && formation != null)

--- a/Alliance.Server/Patch/HarmonyPatch/Patch_MissionNetworkComponent.cs
+++ b/Alliance.Server/Patch/HarmonyPatch/Patch_MissionNetworkComponent.cs
@@ -246,14 +246,14 @@ namespace Alliance.Server.Patch.HarmonyPatch
 			Team teamOfPeer = (Team)(typeof(MissionNetworkComponent).GetMethod("GetTeamOfPeer",
 						BindingFlags.Instance | BindingFlags.NonPublic)?
 						.Invoke(__instance, new object[] { networkPeer }));
-			OrderController orderController = teamOfPeer != null ? teamOfPeer.GetOrderControllerOf(networkPeer.ControlledAgent) : null;
+			OrderController orderController = teamOfPeer?.GetOrderControllerOf(networkPeer.ControlledAgent);
 
 			// Remove check on CountOfUnits to allow transfer to empty formations
-			Formation formation = teamOfPeer != null ? teamOfPeer.FormationsIncludingEmpty.SingleOrDefault((f) => /*f.CountOfUnits > 0 && */f.Index == message.FormationIndex) : null;
+			Formation formation = teamOfPeer?.FormationsIncludingEmpty.SingleOrDefault((f) => /*f.CountOfUnits > 0 && */f.Index == message.FormationIndex);
 
 			// Give control to player
 			Log($"Giving control of formation {formation.Index} to {networkPeer.UserName}", LogLevel.Information);
-			FormationControlModel.Instance.AssignControlToPlayer(networkPeer.GetComponent<MissionPeer>(), formation.FormationIndex, true);
+			FormationControlModel.Instance.AssignControlToPlayer(networkPeer.GetComponent<MissionPeer>(), teamOfPeer, formation.FormationIndex, true);
 
 			int number = message.Number;
 			if (teamOfPeer != null && orderController != null && formation != null)

--- a/Alliance.Server/_Module/SubModule.xml
+++ b/Alliance.Server/_Module/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Id value="Alliance" />
   <Name value="Alliance" />
-  <Version value="v0.5.6.0" />
+  <Version value="v0.5.7.0" />
   <ModuleCategory value="Multiplayer" />
   <DependedModules>
     <DependedModule Id="Native" />


### PR DESCRIPTION
# PvC and UI Improvements (#108)

## Summary
This release introduces officer elections for PvC, improves UI and fixes several issues related to the Troop and Player spawn menus.

## Features

### Gameplay
- Added officer elections to PvC
- Admins can no longer recruit troops through the Troop Spawn menu without sufficient gold (they can still use the dedicated admin shortcut to spawn units at cursor position)

### Troop Spawn menu
- Reworked underlying commanders synchronization system for improved reliability

### Player Spawn menu
- Restored native Sandbox kingdom brushes used for officer election
- Troop previews now temporarily use the native CharacterTableau system, eliminating rendering artifacts and reducing stuttering while the custom renderer is being reworked

### All menus
- Added scrollbars to perk lists to allow more than the 3 native slots

## Fixes
- Fixed formation information not displaying correctly in the Troop Spawn menu
- Fixed obsolete or missing commander information shown in formation displays
- Fixed a crash in PvC when a player joined the server without being assigned to a team
- Fixed the perk tooltip following the mouse cursor in the Player Spawn menu
- Added validation when loading spawn configurations to prevent invalid character references

---------

Co-authors: @Byak0