### PR TITLE
Poll structure - WIP

### DIFF
--- a/.github/agents/tw-native-explorer.agent.md
+++ b/.github/agents/tw-native-explorer.agent.md
@@ -1,0 +1,103 @@
+---
+name: tw-native-explorer
+description: >
+  Specialist in searching and reading decompiled native TaleWorlds (Bannerlord) code.
+  Explores, locates and analyzes classes, methods and types from the TaleWorlds engine
+  using the decompiled source code available under Alliance.Common/TW_References/BannerlordSource/.
+tools:
+  - run_in_terminal   # PowerShell searches in BannerlordSource (required — replaces grep_search/file_search)
+  - read_file         # Read located .cs files
+  - list_dir          # Navigate the BannerlordSource directory tree
+---
+
+You are an expert agent for exploring native TaleWorlds (Mount & Blade II: Bannerlord) code.
+You specialize in searching, reading and analyzing the decompiled source code of TaleWorlds
+assemblies, available under:
+  `Alliance.Common/TW_References/BannerlordSource/`
+
+## Hard scope restriction (MANDATORY)
+
+You are strictly limited to this directory and its children only:
+`Alliance.Common/TW_References/BannerlordSource/`
+
+Before using any tool (`run_in_terminal`, `read_file`, `list_dir`), ensure the target path is inside
+`Alliance.Common/TW_References/BannerlordSource/`.
+
+If a request points to any other location in the repository, refuse and state that the request is out of scope for this agent.
+
+## Decompiled source structure
+
+The BannerlordSource folder is organized by namespace/assembly, for example:
+
+| Path | Assembly |
+|---|---|
+| `TaleWorlds/MountAndBlade/` | TaleWorlds.MountAndBlade.dll (core gameplay) |
+| `TaleWorlds/MountAndBlade/Multiplayer/` | TaleWorlds.MountAndBlade.Multiplayer.dll |
+| `TaleWorlds/Core/` | TaleWorlds.Core.dll |
+| `TaleWorlds/Engine/` | TaleWorlds.Engine.dll |
+| `TaleWorlds/Library/` | TaleWorlds.Library.dll |
+| `TaleWorlds/CampaignSystem/` | TaleWorlds.CampaignSystem.dll |
+| `Sandbox/` | SandBox.dll |
+| `Storymode/` | StoryMode.dll |
+
+## Search strategy
+
+> ⚠️ **IMPORTANT**: Do **NOT** use `grep_search` or `file_search` tools to search in `BannerlordSource/`.
+> These tools rely on workspace indexing, and `BannerlordSource/` is excluded from the index (listed in `.gitignore`).
+> They will return no results even when files exist on disk.
+> **Always use terminal commands (PowerShell) instead.**
+>
+> You must run searches only inside:
+> `Alliance.Common/TW_References/BannerlordSource/`
+
+Use the following PowerShell command pattern to search for a type or symbol:
+
+```powershell
+Get-ChildItem -Path "XXXX\Alliance\Alliance.Common\TW_References\BannerlordSource" -Recurse -Filter "*.cs" | Select-String -Pattern "SymbolName" -List
+```
+
+Replace `XXXX` with the actual path to the workspace root, and `SymbolName` with the class, method, or pattern to search for.
+
+1. Always start by running a PowerShell search against `BannerlordSource/` using the command above.
+2. Use the namespace hierarchy to navigate efficiently once the file is located.
+3. Read the relevant `.cs` files to understand signatures, inheritance and behaviors.
+4. Cross-reference multiple files when needed (e.g. base class + derived class).
+5. Report information concisely: full signature, inheritance chain, important members.
+6. Do not inspect any file outside `BannerlordSource/`.
+
+## If the source code is missing or incomplete
+
+If `BannerlordSource/` is empty, missing, or if searched files cannot be found,
+clearly state it and propose the following actions in priority order:
+
+1. **ILSpy not installed?** → Run first:
+   `Alliance.Common/TW_References/Install ILSpy.bat`
+   (installs ilspycmd via dotnet tool: `dotnet tool install --global ilspycmd --version 8.0.0.7246-preview3`)
+
+2. **Generate the source code** → Then run:
+   `Alliance.Common/TW_References/Decompile.bat`
+   (decompiles all TaleWorlds DLLs into BannerlordSource/ — requires `BANNERLORD_GAME_DIR`)
+
+3. **PDB files for debugging** → Only if needed for crash debugging:
+   `Alliance.Common/TW_References/GenPDB.bat`
+   (generates `.pdb` files and copies them to the game directory)
+
+> ⚠️ **IMPORTANT**: These operations are time-consuming and resource-intensive.
+> Only suggest them if files are genuinely not found after searching `BannerlordSource/`.
+> **NEVER** run these scripts automatically — always require explicit user confirmation.
+
+## What you must provide
+
+- Exact file location (relative path from the workspace root)
+- Full signature of the searched types/methods
+- Inheritance hierarchy when relevant
+- Contextual code excerpts (key methods, important properties)
+- Usage patterns observed in the native code
+
+## What you must NOT do
+
+- Invent or assume native code not present in `BannerlordSource/`
+- Read, list, or search files outside `Alliance.Common/TW_References/BannerlordSource/`
+- Run terminal commands that target paths outside `Alliance.Common/TW_References/BannerlordSource/`
+- Modify any files in `TW_References/` or `BannerlordSource/`
+- Run `Decompile.bat`, `GenPDB.bat` or `Install ILSpy.bat` without explicit user confirmation

--- a/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
+++ b/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
@@ -1,0 +1,43 @@
+using Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Client.Extensions.NativeIntermissionVote.Handlers
+{
+	/// <summary>
+	/// Handles client-side synchronization required by Alliance custom native intermission vote flows.
+	/// Registered globally because native intermission voting runs after mission behaviors are removed.
+	/// </summary>
+	internal static class NativeIntermissionVoteHandler
+	{
+		private static bool _registered;
+
+		public static void Register()
+		{
+			if (_registered)
+			{
+				return;
+			}
+
+			GameNetwork.NetworkMessageHandlerRegisterer reg = new GameNetwork.NetworkMessageHandlerRegisterer(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Add);
+			reg.Register<ClearNativeIntermissionVoteItems>(HandleClearNativeIntermissionVoteItems);
+			_registered = true;
+		}
+
+		private static void HandleClearNativeIntermissionVoteItems(ClearNativeIntermissionVoteItems message)
+		{
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			if (votingManager == null)
+			{
+				Log("Failed to clear native intermission vote items: MultiplayerIntermissionVotingManager is missing.", LogLevel.Warning);
+				return;
+			}
+
+			votingManager.ClearVotes();
+			votingManager.ClearItems();
+			Log("Native intermission vote items cleared on client.", LogLevel.Debug);
+		}
+	}
+}
+
+

--- a/Alliance.Client/SubModule.cs
+++ b/Alliance.Client/SubModule.cs
@@ -1,4 +1,5 @@
 ﻿using Alliance.Client.Core.Providers;
+using Alliance.Client.Extensions.NativeIntermissionVote.Handlers;
 using Alliance.Client.GameModes.BattleRoyale;
 using Alliance.Client.GameModes.BattleX;
 using Alliance.Client.GameModes.CaptainX;
@@ -73,6 +74,7 @@ namespace Alliance.Client
 
 			SceneList.Initialize();
 			ScenarioPlayer.Initialize();
+			NativeIntermissionVoteHandler.Register();
 		}
 
 		private void AddGameModes()

--- a/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
+++ b/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
@@ -148,6 +148,8 @@ namespace Alliance.Common.Core.Configuration.Models
 		public bool EnableRaceRestrictionOnStuff = true;
 		[ConfigProperty(true, "Authorize Poll", "Authorize everyone to use the GameMode menu when in Lobby.", category: "Advanced settings")]
 		public bool AuthorizePoll = false;
+		[ConfigProperty(true, "Loop current mode with native vote", "At match end, keep the current game mode and use native intermission votes for map and factions (top voted choices are picked).", category: "Advanced settings")]
+		public bool LoopCurrentModeWithNativeVote = false;
 
 		public DefaultConfig()
 		{

--- a/Alliance.Common/Core/Utils/CompressionHelper.cs
+++ b/Alliance.Common/Core/Utils/CompressionHelper.cs
@@ -15,6 +15,9 @@ namespace Alliance.Common.Core.Utils
 		public static readonly CompressionInfo.Float DefaultFloatValueCompressionInfo = new(0f, 10, 0.01f);
 		public static readonly CompressionInfo.Integer LanguageCompressionInfo = new(0, LocalizationHelper.GetAvailableLanguages().Count - 1);
 		public static readonly CompressionInfo.Integer AgentDataTypeCompressionInfo = new(0, (int)AgentDataType.All);
+		public static readonly CompressionInfo.Integer TeamIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
+		public static readonly CompressionInfo.Integer FormationIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
+		public static readonly CompressionInfo.Integer CharacterIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
 		public static readonly int StringMaxLength = 512;
 	}
 }

--- a/Alliance.Common/Extensions/NativeIntermissionVote/NetworkMessages/FromServer/ClearNativeIntermissionVoteItems.cs
+++ b/Alliance.Common/Extensions/NativeIntermissionVote/NetworkMessages/FromServer/ClearNativeIntermissionVoteItems.cs
@@ -1,0 +1,33 @@
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer
+{
+	/// <summary>
+	/// Clears native intermission vote items on clients before the server broadcasts its custom vote pool.
+	/// TaleWorlds native item messages only append items and update vote counts by index.
+	/// </summary>
+	[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+	public sealed class ClearNativeIntermissionVoteItems : GameNetworkMessage
+	{
+		protected override void OnWrite()
+		{
+		}
+
+		protected override bool OnRead()
+		{
+			return true;
+		}
+
+		protected override MultiplayerMessageFilter OnGetLogFilter()
+		{
+			return MultiplayerMessageFilter.Administration;
+		}
+
+		protected override string OnGetLogFormat()
+		{
+			return "Clear native intermission vote items";
+		}
+	}
+}
+

--- a/Alliance.Common/Extensions/PlayerPoll/Models/Poll.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/Models/Poll.cs
@@ -1,0 +1,167 @@
+﻿using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Common.Extensions.PlayerPoll.Models
+{
+	public enum PollType
+	{
+		SingleChoice,
+		MultipleChoices,
+		YesNo
+	}
+
+	public enum PollState
+	{
+		Pending,
+		Active,
+		Ended
+	}
+
+	public enum PollAudienceType
+	{
+		All,
+		TeamOnly,
+		FormationOnly,
+		OfficersOnly,
+		AdminsOnly
+	}
+
+	public readonly struct PollAudience
+	{
+		public PollAudienceType AudienceType { get; }
+		public int? TeamIndex { get; }
+		public int? FormationIndex { get; }
+
+		public PollAudience(PollAudienceType audienceType, int? teamIndex = null, int? formationIndex = null)
+		{
+			AudienceType = audienceType;
+			TeamIndex = teamIndex;
+			FormationIndex = formationIndex;
+		}
+	}
+
+	public struct PollHeader
+	{
+		public int Id { get; }
+		public PollType Type { get; }
+		public PollAudience Audience { get; }
+		public byte DurationSeconds { get; }
+		public NetworkCommunicator Creator { get; }
+
+		public PollHeader(int id, PollType type, PollAudience audience, byte durationSeconds, NetworkCommunicator creator)
+		{
+			Id = id;
+			Type = type;
+			Audience = audience;
+			DurationSeconds = durationSeconds;
+			Creator = creator;
+		}
+	}
+
+	public class Poll
+	{
+		public readonly PollHeader Header;
+		public readonly PollPayloadBase Payload;
+		public readonly List<PollOption> Options = new();
+		public readonly Dictionary<int, PollOption> OptionsById = new();
+		private readonly Dictionary<int, HashSet<int>> _playerSelections = new();
+
+		public DateTime StartTime { get; private set; }
+		public PollState State { get; private set; }
+
+		public event Action<Poll, PollOption> OnPollEnded;
+
+		public Poll(PollHeader header, PollPayloadBase payload)
+		{
+			Header = header;
+			Payload = payload;
+			if (header.Type == PollType.YesNo)
+			{
+				AddOption(new PollOption());
+				AddOption(new PollOption());
+			}
+			State = PollState.Pending;
+		}
+
+		public void Start()
+		{
+			StartTime = DateTime.UtcNow;
+			State = PollState.Active;
+		}
+
+		public void EndPoll()
+		{
+			State = PollState.Ended;
+			OnPollEnded?.Invoke(this, GetWinningOption());
+		}
+
+		public void AddOption(PollOption option)
+		{
+			if (option.Id == -1) option.Id = Options.Count + 1;
+			Options.Add(option);
+			OptionsById[option.Id] = option;
+		}
+
+		public bool RemoveVote(NetworkCommunicator player, int optionId)
+		{
+			//todo player id maybe not pertinent
+			int playerId = player.Index;
+
+			if (!_playerSelections.ContainsKey(playerId)
+				|| !_playerSelections[playerId].Contains(optionId))
+			{
+				return false;
+			}
+
+			if (!OptionsById.TryGetValue(optionId, out PollOption option))
+			{
+				Log($"Poll \"{Header.Id}\" -> Option {optionId} not found", LogLevel.Error);
+				return false; // Invalid option
+			}
+
+			_playerSelections[playerId].Remove(optionId);
+			option.Votes--;
+			return true;
+		}
+
+		public bool AddVote(NetworkCommunicator player, int optionId)
+		{
+			//todo player id maybe not pertinent
+			int playerId = player.Index;
+
+			// Initialize player votes if not present
+			if (!_playerSelections.ContainsKey(playerId)) _playerSelections[playerId] = new HashSet<int>();
+			else if (_playerSelections[playerId].Contains(optionId)) return false;
+
+			if (!OptionsById.TryGetValue(optionId, out PollOption option))
+			{
+				Log($"Poll \"{Header.Id}\" -> Option {optionId} not found", LogLevel.Error);
+				return false; // Invalid option
+			}
+
+			// Clear previous votes if single choice
+			if (Header.Type == PollType.SingleChoice || Header.Type == PollType.YesNo)
+			{
+				foreach (int selectedOptionId in _playerSelections[playerId])
+				{
+					if (OptionsById.TryGetValue(selectedOptionId, out PollOption previousOption))
+					{
+						previousOption.Votes--;
+					}
+				}
+				_playerSelections[playerId].Clear();
+			}
+
+			_playerSelections[playerId].Add(option.Id);
+			option.Votes++;
+
+			return true;
+		}
+
+		public PollOption GetWinningOption() => Options.OrderByDescending(o => o.Votes).FirstOrDefault();
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/Models/PollOption.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/Models/PollOption.cs
@@ -1,0 +1,25 @@
+﻿using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads;
+
+namespace Alliance.Common.Extensions.PlayerPoll.Models
+{
+	public struct PollOption
+	{
+		public int Id { get; set; }
+		public int Votes { get; set; }
+		public PollPayloadBase Payload { get; }
+
+		public PollOption(PollPayloadBase payload = null)
+		{
+			Id = -1;
+			Votes = 0;
+			Payload = payload;
+		}
+
+		public PollOption(int optionId, int votes, PollPayloadBase optionPayload) : this()
+		{
+			Id = optionId;
+			Votes = votes;
+			Payload = optionPayload;
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromClient/VoteForPoll.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromClient/VoteForPoll.cs
@@ -1,0 +1,51 @@
+﻿using Alliance.Common.Core.Utils;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.FromClient
+{
+	[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromClient)]
+	public sealed class VoteForPoll : GameNetworkMessage
+	{
+		public int PollId { get; private set; }
+		public int OptionId { get; private set; }
+		public bool Add { get; private set; } = true;
+
+		public VoteForPoll(int pollId, int optionId, bool add = true)
+		{
+			PollId = pollId;
+			OptionId = optionId;
+			Add = add;
+		}
+
+		public VoteForPoll()
+		{
+		}
+
+		protected override void OnWrite()
+		{
+			WriteIntToPacket(PollId, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteIntToPacket(OptionId, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteBoolToPacket(Add);
+		}
+
+		protected override bool OnRead()
+		{
+			bool bufferReadValid = true;
+			PollId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			OptionId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			Add = ReadBoolFromPacket(ref bufferReadValid);
+			return bufferReadValid;
+		}
+
+		protected override MultiplayerMessageFilter OnGetLogFilter()
+		{
+			return MultiplayerMessageFilter.Mission;
+		}
+
+		protected override string OnGetLogFormat()
+		{
+			return $"Alliance - PlayerPoll - Requesting to {(Add ? "vote for" : "remove vote for")} option {OptionId} in poll {PollId}";
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromServer/CreatePoll.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromServer/CreatePoll.cs
@@ -1,0 +1,136 @@
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerPoll.Models;
+using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads;
+using System.Collections.Generic;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.FromServer
+{
+	[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+	public sealed class CreatePoll : GameNetworkMessage
+	{
+		public Poll Poll { get; private set; }
+
+		public CreatePoll(Poll poll)
+		{
+			Poll = poll;
+		}
+
+		public CreatePoll()
+		{
+		}
+
+		protected override bool OnRead()
+		{
+			bool bufferReadValid = true;
+			int pollId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			PollType pollType = (PollType)ReadIntFromPacket(PollMsg.PollTypeCompressionInfo, ref bufferReadValid);
+			PollAudienceType audienceType = (PollAudienceType)ReadIntFromPacket(PollMsg.PollAudienceTypeCompressionInfo, ref bufferReadValid);
+			int? teamIndex = null;
+			int? formationIndex = null;
+			if (audienceType == PollAudienceType.TeamOnly)
+			{
+				teamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			}
+			else if (audienceType == PollAudienceType.FormationOnly)
+			{
+				teamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+				formationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
+			}
+			byte durationSeconds = (byte)ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			NetworkCommunicator creator = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
+			PollHeader header = new(pollId, pollType, new PollAudience(audienceType, teamIndex, formationIndex), durationSeconds, creator);
+
+			int payloadTypeId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			PollPayloadBase payload = null;
+			if (payloadTypeId != -1)
+			{
+				payload = PollPayloadRegistry.Create(payloadTypeId);
+				payload?.ReadFromPacket(ref bufferReadValid);
+			}
+
+			int optionsCount = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			var options = new List<PollOption>();
+			for (int i = 0; i < optionsCount; i++)
+			{
+				int optionId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+				int votes = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+				int optionPayloadTypeId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+				PollPayloadBase optionPayload = null;
+				if (optionPayloadTypeId != -1)
+				{
+					optionPayload = PollPayloadRegistry.Create(optionPayloadTypeId);
+					optionPayload?.ReadFromPacket(ref bufferReadValid);
+				}
+				options.Add(new PollOption(optionId, votes, optionPayload));
+			}
+			Poll = new Poll(header, payload);
+			foreach (var option in options)
+			{
+				Poll.Options.Add(option);
+			}
+
+			return bufferReadValid;
+		}
+
+		protected override void OnWrite()
+		{
+			WriteIntToPacket(Poll.Header.Id, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteIntToPacket((int)Poll.Header.Type, PollMsg.PollTypeCompressionInfo);
+
+			WriteIntToPacket((int)Poll.Header.Audience.AudienceType, PollMsg.PollAudienceTypeCompressionInfo);
+			if (Poll.Header.Audience.AudienceType == PollAudienceType.TeamOnly
+				&& Poll.Header.Audience.TeamIndex.HasValue)
+			{
+				WriteIntToPacket(Poll.Header.Audience.TeamIndex.Value, CompressionHelper.TeamIndexCompressionInfo);
+			}
+			else if (Poll.Header.Audience.AudienceType == PollAudienceType.FormationOnly
+				&& Poll.Header.Audience.FormationIndex.HasValue
+				&& Poll.Header.Audience.TeamIndex.HasValue)
+			{
+				WriteIntToPacket(Poll.Header.Audience.TeamIndex.Value, CompressionHelper.TeamIndexCompressionInfo);
+				WriteIntToPacket(Poll.Header.Audience.FormationIndex.Value, CompressionHelper.FormationIndexCompressionInfo);
+			}
+
+			WriteIntToPacket(Poll.Header.DurationSeconds, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteNetworkPeerReferenceToPacket(Poll.Header.Creator);
+
+			if (Poll.Payload != null)
+			{
+				WriteIntToPacket(Poll.Payload.TypeId, CompressionHelper.DefaultIntValueCompressionInfo);
+				Poll.Payload.WriteToPacket();
+			}
+			else
+			{
+				WriteIntToPacket(-1, CompressionHelper.DefaultIntValueCompressionInfo);
+			}
+
+			WriteIntToPacket(Poll.Options.Count, CompressionHelper.DefaultIntValueCompressionInfo);
+			foreach (PollOption option in Poll.Options)
+			{
+				WriteIntToPacket(option.Id, CompressionHelper.DefaultIntValueCompressionInfo);
+				WriteIntToPacket(option.Votes, CompressionHelper.DefaultIntValueCompressionInfo);
+				if (option.Payload != null)
+				{
+					WriteIntToPacket(option.Payload.TypeId, CompressionHelper.DefaultIntValueCompressionInfo);
+					option.Payload.WriteToPacket();
+				}
+				else
+				{
+					WriteIntToPacket(-1, CompressionHelper.DefaultIntValueCompressionInfo);
+				}
+			}
+		}
+
+		protected override MultiplayerMessageFilter OnGetLogFilter()
+		{
+			return MultiplayerMessageFilter.Peers;
+		}
+
+		protected override string OnGetLogFormat()
+		{
+			return $"Alliance - PlayerPoll - Syncing poll '{Poll.Header.Id}' with {Poll.Options.Count} options";
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromServer/UpdatePollVote.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/FromServer/UpdatePollVote.cs
@@ -1,0 +1,51 @@
+﻿using Alliance.Common.Core.Utils;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.FromServer
+{
+	[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+	public sealed class UpdatePollVote : GameNetworkMessage
+	{
+		public int PollId;
+		public int OptionId;
+		public int NewVoteCount;
+
+		public UpdatePollVote(int pollId, int optionId, int newVoteCount)
+		{
+			PollId = pollId;
+			OptionId = optionId;
+			NewVoteCount = newVoteCount;
+		}
+
+		public UpdatePollVote()
+		{
+		}
+
+		protected override bool OnRead()
+		{
+			bool bufferReadValid = true;
+			PollId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			OptionId = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			NewVoteCount = ReadIntFromPacket(CompressionHelper.DefaultIntValueCompressionInfo, ref bufferReadValid);
+			return bufferReadValid;
+		}
+
+		protected override void OnWrite()
+		{
+			WriteIntToPacket(PollId, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteIntToPacket(OptionId, CompressionHelper.DefaultIntValueCompressionInfo);
+			WriteIntToPacket(NewVoteCount, CompressionHelper.DefaultIntValueCompressionInfo);
+		}
+
+		protected override MultiplayerMessageFilter OnGetLogFilter()
+		{
+			return MultiplayerMessageFilter.Peers;
+		}
+
+		protected override string OnGetLogFormat()
+		{
+			return $"Alliance - PlayerPoll - Updating poll {PollId} - option {OptionId} with new vote count : {NewVoteCount}";
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/GameModePollPayload.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/GameModePollPayload.cs
@@ -1,0 +1,33 @@
+﻿using Alliance.Common.Core.Configuration.Models;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads
+{
+	public class GameModePollPayload : PollPayloadBase
+	{
+		public TWConfig NativeOptions { get; }
+		public Config ModOptions { get; }
+
+		public GameModePollPayload(TWConfig twConfig, Config config) : base((int)PollPayloadRegistry.PollPayloadType.GameMode)
+		{
+			NativeOptions = twConfig;
+			ModOptions = config;
+		}
+
+		public GameModePollPayload() : base((int)PollPayloadRegistry.PollPayloadType.GameMode)
+		{
+		}
+
+		public override void WriteToPacket()
+		{
+			// todo
+			//WriteNativeOptions();
+			//WriteModOptions();
+		}
+		public override void ReadFromPacket(ref bool bufferReadValid)
+		{
+			// todo
+			//ReadNativeOptions(ref bufferReadValid);
+			//ReadModOptions(ref bufferReadValid);
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/OfficerPollPayload.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/OfficerPollPayload.cs
@@ -1,0 +1,27 @@
+﻿using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads
+{
+	public class OfficerPollPayload : PollPayloadBase
+	{
+		public NetworkCommunicator Target { get; }
+
+		public OfficerPollPayload(NetworkCommunicator target) : base((int)PollPayloadRegistry.PollPayloadType.Officer)
+		{
+			Target = target;
+		}
+
+		public OfficerPollPayload() : base((int)PollPayloadRegistry.PollPayloadType.Officer)
+		{
+		}
+
+		public override void WriteToPacket()
+		{
+			// todo
+		}
+		public override void ReadFromPacket(ref bool bufferReadValid)
+		{
+			// todo
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/PollPayloadBase.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/PollPayloadBase.cs
@@ -1,0 +1,19 @@
+﻿namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads
+{
+	/// <summary>
+	/// Base class for different poll payload types.
+	/// Register the payload types in PollPayloadRegistry.
+	/// </summary>
+	public abstract class PollPayloadBase
+	{
+		public int TypeId { get; private set; }
+
+		public PollPayloadBase(int typeId)
+		{
+			TypeId = typeId;
+		}
+
+		public abstract void WriteToPacket();
+		public abstract void ReadFromPacket(ref bool bufferReadValid);
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/QuestionPollPayload.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/Payloads/QuestionPollPayload.cs
@@ -1,0 +1,25 @@
+﻿namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads
+{
+	public class QuestionPollPayload : PollPayloadBase
+	{
+		public string Question { get; }
+
+		public QuestionPollPayload(string question) : base((int)PollPayloadRegistry.PollPayloadType.Question)
+		{
+			Question = question;
+		}
+
+		public QuestionPollPayload() : base((int)PollPayloadRegistry.PollPayloadType.Question)
+		{
+		}
+
+		public override void WriteToPacket()
+		{
+			// todo
+		}
+		public override void ReadFromPacket(ref bool bufferReadValid)
+		{
+			// todo
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/PollMsg.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/PollMsg.cs
@@ -1,0 +1,54 @@
+﻿using Alliance.Common.Extensions.PlayerPoll.Models;
+using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.FromClient;
+using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.FromServer;
+using System;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages
+{
+	public static class PollMsg
+	{
+		public static readonly CompressionInfo.Integer PollTypeCompressionInfo = new CompressionInfo.Integer(0, Enum.GetValues(typeof(PollType)).Length, true);
+		public static readonly CompressionInfo.Integer PollAudienceTypeCompressionInfo = new CompressionInfo.Integer(0, Enum.GetValues(typeof(PollAudienceType)).Length, true);
+
+		/// <summary>
+		/// From server - Broadcast new vote count for a poll option.
+		/// </summary>
+		public static void UpdatePollVote(int pollId, int optionId, int newCount)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(new UpdatePollVote(pollId, optionId, newCount));
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+
+		/// <summary>
+		/// From server - Broadcast a new poll.
+		/// </summary>
+		public static void CreatePoll(Poll poll)
+		{
+			GameNetwork.BeginBroadcastModuleEvent();
+			GameNetwork.WriteMessage(new CreatePoll(poll));
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+		}
+
+		/// <summary>
+		/// From server - Send poll to a player.
+		/// </summary>
+		public static void CreatePoll(NetworkCommunicator peer, Poll poll)
+		{
+			GameNetwork.BeginModuleEventAsServer(peer);
+			GameNetwork.WriteMessage(new CreatePoll(poll));
+			GameNetwork.EndModuleEventAsServer();
+		}
+
+		/// <summary>
+		/// From client - Vote for a poll option.
+		/// </summary>
+		public static void RequestVoteForPoll(int pollId, int optionId, bool add = true)
+		{
+			GameNetwork.BeginModuleEventAsClient();
+			GameNetwork.WriteMessage(new VoteForPoll(pollId, optionId, add));
+			GameNetwork.EndModuleEventAsClient();
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/PollPayloadRegistry.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/NetworkMessages/PollPayloadRegistry.cs
@@ -1,0 +1,25 @@
+﻿using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads;
+using System;
+using System.Collections.Generic;
+
+namespace Alliance.Common.Extensions.PlayerPoll.NetworkMessages
+{
+	public static class PollPayloadRegistry
+	{
+		public enum PollPayloadType
+		{
+			GameMode = 1,
+			Officer = 2,
+			Question = 3,
+		}
+
+		private static readonly Dictionary<PollPayloadType, Func<PollPayloadBase>> _create = new()
+		{
+			{ PollPayloadType.GameMode, () => new GameModePollPayload() },
+			{ PollPayloadType.Officer,  () => new OfficerPollPayload() },
+			{ PollPayloadType.Question, () => new QuestionPollPayload() },
+		};
+
+		public static PollPayloadBase Create(int type) => _create[(PollPayloadType)type]();
+	}
+}

--- a/Alliance.Common/Extensions/PlayerPoll/PollManager.cs
+++ b/Alliance.Common/Extensions/PlayerPoll/PollManager.cs
@@ -1,0 +1,105 @@
+﻿using Alliance.Common.Extensions.PlayerPoll.Models;
+using Alliance.Common.Extensions.PlayerPoll.NetworkMessages;
+using Alliance.Common.Extensions.PlayerPoll.NetworkMessages.Payloads;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Common.Extensions.PlayerPoll
+{
+	public class PollManager
+	{
+		private static PollManager _instance;
+
+		public static PollManager Instance
+		{
+			get
+			{
+				_instance ??= new PollManager();
+				return _instance;
+			}
+		}
+
+		private int _nextPollId = 0;
+		public readonly Dictionary<int, Poll> ActivePolls = new();
+		public readonly Dictionary<int, Poll> EndedPolls = new();
+
+		private PollManager() { }
+
+		public void RemoveVote(NetworkCommunicator player, int pollId, int optionId)
+		{
+			UpdateVote(player, pollId, optionId, false);
+		}
+
+		public void AddVote(NetworkCommunicator player, int pollId, int optionId)
+		{
+			UpdateVote(player, pollId, optionId, true);
+		}
+
+		private void UpdateVote(NetworkCommunicator player, int pollId, int optionId, bool add = true)
+		{
+			if (!ActivePolls.TryGetValue(pollId, out var poll)) return;
+
+			bool changed = add ? poll.AddVote(player, optionId) : poll.RemoveVote(player, optionId);
+			if (changed && GameNetwork.IsServer) PollMsg.UpdatePollVote(pollId, optionId, poll.OptionsById[optionId].Votes);
+		}
+
+		public void Tick(float dt)
+		{
+			List<int> pollsToRemove = new();
+			foreach (Poll poll in ActivePolls.Values)
+			{
+				if (poll.State == PollState.Active && (DateTime.UtcNow - poll.StartTime).TotalSeconds >= poll.Header.DurationSeconds)
+				{
+					poll.EndPoll();
+					EndedPolls.Add(poll.Header.Id, poll);
+					pollsToRemove.Add(poll.Header.Id);
+				}
+			}
+			foreach (var pollId in pollsToRemove)
+			{
+				ActivePolls.Remove(pollId);
+			}
+		}
+
+		public Poll Start(PollAudience audience, PollType type, PollPayloadBase payload, byte durationSeconds, NetworkCommunicator creator, List<PollOption> options = null)
+		{
+			PollHeader header = new PollHeader(_nextPollId++, type, audience, durationSeconds, creator);
+			Poll poll = new Poll(header, payload);
+			foreach (PollOption option in options)
+			{
+				poll.AddOption(option);
+			}
+			ActivePolls.Add(poll.Header.Id, poll);
+			poll.Start();
+			return poll;
+		}
+
+		public Poll CreateYesNoPoll()
+		{
+			Poll poll1 = Start(
+				new PollAudience(PollAudienceType.All),
+				PollType.YesNo,
+				new QuestionPollPayload("Is this a dummy poll?"),
+				30,
+				GameNetwork.MyPeer
+			);
+
+			Poll poll2 = Start(
+				new PollAudience(PollAudienceType.FormationOnly, 0, 2),
+				PollType.SingleChoice,
+				new QuestionPollPayload("Choose your next officer :"),
+				30,
+				GameNetwork.MyPeer,
+				new List<PollOption>
+				{
+					new PollOption(new OfficerPollPayload(GameNetwork.MyPeer)),
+					new PollOption(new OfficerPollPayload(GameNetwork.MyPeer)),
+					new PollOption(new OfficerPollPayload(GameNetwork.MyPeer)),
+				}
+			);
+
+			return poll1;
+		}
+	}
+}

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/RequestCharacterUsage.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/RequestCharacterUsage.cs
@@ -1,8 +1,8 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using System.Collections.Generic;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 {
@@ -33,9 +33,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 
 		protected override void OnWrite()
 		{
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
-			WriteIntToPacket(CharacterIndex, CharacterIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
+			WriteIntToPacket(CharacterIndex, CompressionHelper.CharacterIndexCompressionInfo);
 			WriteIntToPacket(NbPerks, CompressionMission.PerkIndexCompressionInfo);
 			foreach (int selectedPerk in SelectedPerks)
 			{
@@ -46,9 +46,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
-			CharacterIndex = ReadIntFromPacket(CharacterIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
+			CharacterIndex = ReadIntFromPacket(CompressionHelper.CharacterIndexCompressionInfo, ref bufferReadValid);
 			NbPerks = ReadIntFromPacket(CompressionMission.PerkIndexCompressionInfo, ref bufferReadValid);
 			SelectedPerks = new List<int>();
 			for (int i = 0; i < NbPerks; i++)

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/RequestOfficerUsage.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/RequestOfficerUsage.cs
@@ -1,8 +1,8 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using System.Collections.Generic;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 {
@@ -35,9 +35,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 
 		protected override void OnWrite()
 		{
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
-			WriteIntToPacket(CharacterIndex, CharacterIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
+			WriteIntToPacket(CharacterIndex, CompressionHelper.CharacterIndexCompressionInfo);
 			WriteIntToPacket(NbPerks, CompressionMission.PerkIndexCompressionInfo);
 			foreach (int selectedPerk in SelectedPerks)
 			{
@@ -49,9 +49,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
-			CharacterIndex = ReadIntFromPacket(CharacterIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
+			CharacterIndex = ReadIntFromPacket(CompressionHelper.CharacterIndexCompressionInfo, ref bufferReadValid);
 			NbPerks = ReadIntFromPacket(CompressionMission.PerkIndexCompressionInfo, ref bufferReadValid);
 			SelectedPerks = new List<int>();
 			for (int i = 0; i < NbPerks; i++)

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/UpdatePlayerSpawnMenu.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromClient/UpdatePlayerSpawnMenu.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
 using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
@@ -71,15 +72,15 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 				case PlayerSpawnMenuOperation.AddFormation:
 				case PlayerSpawnMenuOperation.UpdateFormation:
 				case PlayerSpawnMenuOperation.RemoveFormation:
-					WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
+					WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
 					WritePlayerFormationToPacket(PlayerFormation);
 					break;
 
 				case PlayerSpawnMenuOperation.AddCharacter:
 				case PlayerSpawnMenuOperation.UpdateCharacter:
 				case PlayerSpawnMenuOperation.RemoveCharacter:
-					WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-					WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+					WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+					WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 					WriteAvailableCharacterToPacket(AvailableCharacter);
 					break;
 
@@ -110,14 +111,14 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromClient
 				case PlayerSpawnMenuOperation.AddFormation:
 				case PlayerSpawnMenuOperation.UpdateFormation:
 				case PlayerSpawnMenuOperation.RemoveFormation:
-					TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
+					TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
 					PlayerFormation = ReadPlayerFormationFromPacket(ref bufferReadValid);
 					break;
 				case PlayerSpawnMenuOperation.AddCharacter:
 				case PlayerSpawnMenuOperation.UpdateCharacter:
 				case PlayerSpawnMenuOperation.RemoveCharacter:
-					TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-					FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+					TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+					FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 					AvailableCharacter = ReadAvailableCharacterFromPacket(ref bufferReadValid);
 					break;
 				case PlayerSpawnMenuOperation.EndMenuSync:

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/AddCharacterUsage.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/AddCharacterUsage.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -31,18 +31,18 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(Player);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
-			WriteIntToPacket(CharacterIndex, CharacterIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
+			WriteIntToPacket(CharacterIndex, CompressionHelper.CharacterIndexCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
 			Player = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
-			CharacterIndex = ReadIntFromPacket(CharacterIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
+			CharacterIndex = ReadIntFromPacket(CompressionHelper.CharacterIndexCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/AddOfficerCandidacy.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/AddOfficerCandidacy.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -33,9 +33,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(Player);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
-			WriteIntToPacket(CharacterIndex, CharacterIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
+			WriteIntToPacket(CharacterIndex, CompressionHelper.CharacterIndexCompressionInfo);
 			WriteStringToPacket(Pitch);
 		}
 
@@ -43,9 +43,9 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		{
 			bool bufferReadValid = true;
 			Player = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
-			CharacterIndex = ReadIntFromPacket(CharacterIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
+			CharacterIndex = ReadIntFromPacket(CompressionHelper.CharacterIndexCompressionInfo, ref bufferReadValid);
 			Pitch = ReadStringFromPacket(ref bufferReadValid);
 			return bufferReadValid;
 		}

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/RemoveOfficerCandidacy.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/RemoveOfficerCandidacy.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -29,16 +29,16 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(Player);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
 			Player = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/RemovePlayerFromFormation.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/RemovePlayerFromFormation.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -29,16 +29,16 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(Player);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
 			Player = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SetFormationOfficer.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SetFormationOfficer.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -29,16 +29,16 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(NewOfficer);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
 			NewOfficer = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SetPlayerTeam.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SetPlayerTeam.cs
@@ -1,7 +1,7 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -27,14 +27,14 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 		protected override void OnWrite()
 		{
 			WriteNetworkPeerReferenceToPacket(Player);
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
 			Player = ReadNetworkPeerReferenceFromPacket(ref bufferReadValid);
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SyncFormationMainLanguage.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SyncFormationMainLanguage.cs
@@ -2,7 +2,6 @@
 using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
-using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
 
 namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 {
@@ -29,16 +28,16 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 
 		protected override void OnWrite()
 		{
-			WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-			WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+			WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+			WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 			WriteIntToPacket(MainLanguageIndex, CompressionHelper.LanguageCompressionInfo);
 		}
 
 		protected override bool OnRead()
 		{
 			bool bufferReadValid = true;
-			TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-			FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+			TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+			FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 			MainLanguageIndex = ReadIntFromPacket(CompressionHelper.LanguageCompressionInfo, ref bufferReadValid);
 			return bufferReadValid;
 		}

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SyncPlayerSpawnMenu.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/FromServer/SyncPlayerSpawnMenu.cs
@@ -1,4 +1,5 @@
-﻿using Alliance.Common.Extensions.PlayerSpawn.Models;
+﻿using Alliance.Common.Core.Utils;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
 using static Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.PlayerSpawnMenuMsg;
@@ -71,15 +72,15 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 				case PlayerSpawnMenuOperation.AddFormation:
 				case PlayerSpawnMenuOperation.UpdateFormation:
 				case PlayerSpawnMenuOperation.RemoveFormation:
-					WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
+					WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
 					WritePlayerFormationToPacket(PlayerFormation);
 					break;
 
 				case PlayerSpawnMenuOperation.AddCharacter:
 				case PlayerSpawnMenuOperation.UpdateCharacter:
 				case PlayerSpawnMenuOperation.RemoveCharacter:
-					WriteIntToPacket(TeamIndex, TeamIndexCompressionInfo);
-					WriteIntToPacket(FormationIndex, FormationIndexCompressionInfo);
+					WriteIntToPacket(TeamIndex, CompressionHelper.TeamIndexCompressionInfo);
+					WriteIntToPacket(FormationIndex, CompressionHelper.FormationIndexCompressionInfo);
 					WriteAvailableCharacterToPacket(AvailableCharacter);
 					break;
 
@@ -111,15 +112,15 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages.FromServer
 				case PlayerSpawnMenuOperation.AddFormation:
 				case PlayerSpawnMenuOperation.UpdateFormation:
 				case PlayerSpawnMenuOperation.RemoveFormation:
-					TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
+					TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
 					PlayerFormation = ReadPlayerFormationFromPacket(ref bufferReadValid);
 					break;
 
 				case PlayerSpawnMenuOperation.AddCharacter:
 				case PlayerSpawnMenuOperation.UpdateCharacter:
 				case PlayerSpawnMenuOperation.RemoveCharacter:
-					TeamIndex = ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
-					FormationIndex = ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+					TeamIndex = ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
+					FormationIndex = ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 					AvailableCharacter = ReadAvailableCharacterFromPacket(ref bufferReadValid);
 					break;
 

--- a/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/PlayerSpawnMenuMsg.cs
+++ b/Alliance.Common/Extensions/PlayerSpawn/NetworkMessages/PlayerSpawnMenuMsg.cs
@@ -20,9 +20,6 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages
 		public static readonly CompressionInfo.Integer OperationCompressionInfo = new CompressionInfo.Integer(0, Enum.GetValues(typeof(PlayerSpawnMenuOperation)).Length, true);
 		public static readonly CompressionInfo.Integer SyncIdCompressionInfo = new CompressionInfo.Integer(-1, 8190, true);
 		public static readonly CompressionInfo.Integer TotalMessageCountCompressionInfo = new CompressionInfo.Integer(-1, 254, true);
-		public static readonly CompressionInfo.Integer TeamIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
-		public static readonly CompressionInfo.Integer FormationIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
-		public static readonly CompressionInfo.Integer CharacterIndexCompressionInfo = new CompressionInfo.Integer(-1, 30, true);
 
 		#region Server Messages
 		/// <summary>
@@ -252,7 +249,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages
 		#region Packet Read/Write Methods - Utilities
 		public static void WritePlayerTeamToPacket(PlayerTeam team)
 		{
-			GameNetworkMessage.WriteIntToPacket(team.Index, TeamIndexCompressionInfo);
+			GameNetworkMessage.WriteIntToPacket(team.Index, CompressionHelper.TeamIndexCompressionInfo);
 			GameNetworkMessage.WriteStringToPacket(team.Name);
 			GameNetworkMessage.WriteIntToPacket((int)team.TeamSide, CompressionMission.TeamSideCompressionInfo);
 		}
@@ -260,7 +257,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages
 		public static PlayerTeam ReadPlayerTeamFromPacket(ref bool bufferReadValid)
 		{
 			PlayerTeam team = new PlayerTeam();
-			team.Index = GameNetworkMessage.ReadIntFromPacket(TeamIndexCompressionInfo, ref bufferReadValid);
+			team.Index = GameNetworkMessage.ReadIntFromPacket(CompressionHelper.TeamIndexCompressionInfo, ref bufferReadValid);
 			team.Name = GameNetworkMessage.ReadStringFromPacket(ref bufferReadValid);
 			team.TeamSide = (BattleSideEnum)GameNetworkMessage.ReadIntFromPacket(CompressionMission.TeamSideCompressionInfo, ref bufferReadValid);
 			return team;
@@ -268,7 +265,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages
 
 		public static void WritePlayerFormationToPacket(PlayerFormation formation)
 		{
-			GameNetworkMessage.WriteIntToPacket(formation.Index, FormationIndexCompressionInfo);
+			GameNetworkMessage.WriteIntToPacket(formation.Index, CompressionHelper.FormationIndexCompressionInfo);
 			GameNetworkMessage.WriteStringToPacket(formation.Name);
 			GameNetworkMessage.WriteObjectReferenceToPacket(formation.MainCulture, CompressionBasic.GUIDCompressionInfo);
 			GameNetworkMessage.WriteBoolToPacket(formation.Settings.UseMorale);
@@ -277,7 +274,7 @@ namespace Alliance.Common.Extensions.PlayerSpawn.NetworkMessages
 		public static PlayerFormation ReadPlayerFormationFromPacket(ref bool bufferReadValid)
 		{
 			PlayerFormation formation = new PlayerFormation();
-			formation.Index = GameNetworkMessage.ReadIntFromPacket(FormationIndexCompressionInfo, ref bufferReadValid);
+			formation.Index = GameNetworkMessage.ReadIntFromPacket(CompressionHelper.FormationIndexCompressionInfo, ref bufferReadValid);
 			formation.Name = GameNetworkMessage.ReadStringFromPacket(ref bufferReadValid);
 			object cultureObject = GameNetworkMessage.ReadObjectReferenceFromPacket(MBObjectManager.Instance, CompressionBasic.GUIDCompressionInfo, ref bufferReadValid);
 			if (cultureObject != null && cultureObject is BasicCultureObject bco)

--- a/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
+++ b/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
@@ -44,6 +44,7 @@ namespace Alliance.Common.GameModes.BattleRoyale
 			return new List<string>
 			{
 				nameof(Config.BRZoneLifeTime),
+				nameof(Config.LoopCurrentModeWithNativeVote),
 				nameof(Config.AllowCustomBody),
 				nameof(Config.RandomizeAppearance),
 				nameof(Config.ShowFlagMarkers),

--- a/Alliance.Common/GameModes/Story/Actions/ActionFactory.cs
+++ b/Alliance.Common/GameModes/Story/Actions/ActionFactory.cs
@@ -51,6 +51,11 @@ namespace Alliance.Common.GameModes.Story.Actions
 			return new StartScenarioAction();
 		}
 
+		public virtual EndScenarioAction EndScenarioAction()
+		{
+			return new EndScenarioAction();
+		}
+
 		public virtual SpawnAgentAction SpawnAgentAction()
 		{
 			return new SpawnAgentAction();

--- a/Alliance.Common/GameModes/Story/Actions/EndScenarioAction.cs
+++ b/Alliance.Common/GameModes/Story/Actions/EndScenarioAction.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Alliance.Common.GameModes.Story.Actions
+{
+	/// <summary>
+	/// Action marking the end of a scenario flow.
+	/// The concrete runtime implementation decides which post-match transition should be started.
+	/// </summary>
+	[Serializable]
+	public class EndScenarioAction : ActionBase
+	{
+		public override void Execute() { }
+	}
+}
+
+

--- a/Alliance.Server/Core/GameModeStarter.cs
+++ b/Alliance.Server/Core/GameModeStarter.cs
@@ -1,8 +1,19 @@
 ﻿using Alliance.Common.Core.Configuration;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.GameModes;
 using Alliance.Common.GameModes.Lobby;
 using NetworkMessages.FromServer;
 using System.Threading;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
+using Alliance.Common.GameModes.Battle;
+using Alliance.Common.GameModes.BattleRoyale;
+using Alliance.Common.GameModes.Captain;
+using Alliance.Common.GameModes.CvC;
+using Alliance.Common.GameModes.Duel;
+using Alliance.Common.GameModes.PvC;
+using Alliance.Common.GameModes.Siege;
+using Alliance.Common.GameModes.Story;
+using Alliance.Server.Extensions.NativeIntermissionVote;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.DedicatedCustomServer;
@@ -53,10 +64,32 @@ namespace Alliance.Server.Core
 
 		private void EndMissionThenStartMission(GameModeSettings gameModeSettings)
 		{
+			MissionListener missionListener = new MissionListener();
+			missionListener.SetGameModeSettings(gameModeSettings);
+			EndMissionWithListener(missionListener, logAgentUsage: true);
+		}
+
+		internal void EndMissionWithListener(IMissionListener listener, bool logAgentUsage = false)
+		{
+			PrepareCurrentMissionForEnd(logAgentUsage);
+			DisableNativeIntermissionVotes();
+
+			Mission.Current.AddListener(listener);
+			EndingCurrentMissionThenStartingNewMission = true;
+			DedicatedCustomServerSubModule.Instance.ServerSideIntermissionManager.EndMission();
+		}
+
+		private void PrepareCurrentMissionForEnd(bool logAgentUsage = false)
+		{
+			if (Mission.Current == null)
+			{
+				return;
+			}
+
 			// Try to stop everyone from using objects to prevent crash
-			Log("Scene=" + Mission.Current?.SceneName, LogLevel.Debug);
-			Log("NB Agents=" + Mission.Current?.Agents.Count, LogLevel.Debug);
-			foreach (MissionObject missionObj in Mission.Current?.MissionObjects)
+			Log("Scene=" + Mission.Current.SceneName, LogLevel.Debug);
+			Log("NB Agents=" + Mission.Current.Agents.Count, LogLevel.Debug);
+			foreach (MissionObject missionObj in Mission.Current.MissionObjects)
 			{
 				if (missionObj is UsableMachine machine)
 				{
@@ -64,36 +97,27 @@ namespace Alliance.Server.Core
 					machine.Disable();
 				}
 			}
-			foreach (Agent agent in Mission.Current?.AllAgents)
+
+			foreach (Agent agent in Mission.Current.AllAgents)
 			{
 				agent.SetMortalityState(Agent.MortalityState.Invulnerable);
-				//UsableMissionObject missionObject = agent.CurrentlyUsedGameObject;
-				//if (missionObject != null)
-				//{
-				//    Log("agent using " + missionObject?.GameEntity?.Name, 0, Debug.DebugColor.Blue);
-				//    agent.StopUsingGameObject();
-				//    Log("agent now using " + agent.CurrentlyUsedGameObject?.GameEntity?.Name, 0, Debug.DebugColor.Blue);
-				//    missionObject.SetDisabled();
-				//}
-				//agent.AIStateFlags = Agent.AIStateFlag.Alarmed;
-				//agent.SetScriptedCombatFlags(Agent.AISpecialCombatModeFlags.None);
-				//agent.DisableScriptedMovement();
-				//agent.ClearTargetFrame();
-				//agent.Detachment?.RemoveAgent(agent);
-				Log($"{agent.Name} using {agent.CurrentlyUsedGameObject?.GameEntity.Name} - flag : {agent.AIStateFlags}  | {agent.GetScriptedCombatFlags()}", LogLevel.Debug);
+				if (logAgentUsage)
+				{
+					Log($"{agent.Name} using {agent.CurrentlyUsedGameObject?.GameEntity.Name} - flag : {agent.AIStateFlags}  | {agent.GetScriptedCombatFlags()}", LogLevel.Debug);
+				}
 			}
+		}
 
-			MissionListener missionListener = new MissionListener();
-			Mission.Current.AddListener(missionListener);
-			MultiplayerIntermissionVotingManager.Instance.IsCultureVoteEnabled = false;
-			MultiplayerIntermissionVotingManager.Instance.IsMapVoteEnabled = false;
-			EndingCurrentMissionThenStartingNewMission = true;
-			missionListener.SetGameModeSettings(gameModeSettings);
-			DedicatedCustomServerSubModule.Instance.ServerSideIntermissionManager.EndMission();
+		private static void DisableNativeIntermissionVotes()
+		{
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			votingManager.IsCultureVoteEnabled = false;
+			votingManager.IsMapVoteEnabled = false;
 		}
 
 		public void ApplyGameModeSettings(GameModeSettings gameModeSettings)
 		{
+			PlayerSpawnMenu.Instance.Clear();
 			ConfigManager.Instance.ApplyNativeOptions(gameModeSettings.TWOptions);
 			ConfigManager.Instance.ApplyModOptions(gameModeSettings.ModOptions);
 			SyncMultiplayerOptionsToClients();
@@ -101,6 +125,12 @@ namespace Alliance.Server.Core
 
 		public bool StartMissionOnly(GameModeSettings gameModeSettings)
 		{
+			if (gameModeSettings == null)
+			{
+				Log("StartMissionOnly called with null settings.", LogLevel.Error);
+				return false;
+			}
+
 			if (!MissionIsRunning)
 			{
 				ApplyGameModeSettings(gameModeSettings);
@@ -120,21 +150,86 @@ namespace Alliance.Server.Core
 			StartMission(lobby);
 		}
 
-		public GameModeStarter()
+		/// <summary>
+		/// Starts the configured post-match transition.
+		/// Defaults to Lobby, or runs the configured intermission flow when enabled.
+		/// </summary>
+		public void StartPostMatchTransition()
 		{
+			string map = OptionType.Map.GetStrValue();
+			string culture1 = OptionType.CultureTeam1.GetStrValue();
+			string culture2 = OptionType.CultureTeam2.GetStrValue();
+
+			if (EndingCurrentMissionThenStartingNewMission)
+			{
+				return;
+			}
+
+			if (Config.Instance.LoopCurrentModeWithNativeVote)
+			{
+				try
+				{
+					GameModeSettings currentGameModeSettings = CreateSettingsFromCurrentOptions();
+					if (NativeIntermissionVoteService.TryStart(this, currentGameModeSettings))
+					{
+						return;
+					}
+
+					Log("Native intermission vote could not be started. Falling back to Lobby.", LogLevel.Warning);
+				}
+				catch
+				{
+					Log("Failed to start native intermission vote. Falling back to Lobby.", LogLevel.Warning);
+				}
+			}
+
+			StartLobby(map, culture1, culture2);
+		}
+
+
+		public GameModeSettings CreateSettingsFromCurrentOptions()
+		{
+			string gameType = OptionType.GameType.GetStrValue();
+			GameModeSettings gameModeSettings;
+
+			switch (gameType)
+			{
+				case "CaptainX": gameModeSettings = new CaptainGameModeSettings(); break;
+				case "BattleX": gameModeSettings = new BattleGameModeSettings(); break;
+				case "SiegeX": gameModeSettings = new SiegeGameModeSettings(); break;
+				case "DuelX": gameModeSettings = new DuelGameModeSettings(); break;
+				case "Scenario": gameModeSettings = new ScenarioGameModeSettings(); break;
+				case "PvC": gameModeSettings = new PvCGameModeSettings(); break;
+				case "CvC": gameModeSettings = new CvCGameModeSettings(); break;
+				case "BattleRoyale": gameModeSettings = new BRGameModeSettings(); break;
+				case "Lobby": gameModeSettings = new LobbyGameModeSettings(); break;
+				default:
+					Log($"Unsupported game type '{gameType}' for loop transition. Falling back to Lobby.", LogLevel.Warning);
+					gameModeSettings = new LobbyGameModeSettings();
+					break;
+			}
+
+			gameModeSettings.TWOptions = ConfigManager.Instance.GetNativeOptionsCopy();
+			gameModeSettings.ModOptions = ConfigManager.Instance.GetModOptionsCopy();
+			return gameModeSettings;
 		}
 	}
 
-	public class MissionListener : IMissionListener
+	internal class MissionListener : IMissionListener
 	{
 		public void SetGameModeSettings(GameModeSettings gameModeSettings)
 		{
 			_gameModeSettings = gameModeSettings;
 		}
 
+		public void SetUseCurrentOptionsForNextMission()
+		{
+			_useCurrentOptionsForNextMission = true;
+		}
+
 		public void OnEndMission()
 		{
-			new Thread(new ParameterizedThreadStart(StartMissionThread.ThreadProc)).Start(_gameModeSettings);
+			new Thread(new ParameterizedThreadStart(StartMissionThread.ThreadProc)).Start(new StartMissionThread.StartMissionRequest(_gameModeSettings, _useCurrentOptionsForNextMission));
 			Mission.Current.RemoveListener(this);
 		}
 
@@ -166,20 +261,38 @@ namespace Alliance.Server.Core
 		{
 		}
 
-		public MissionListener()
-		{
-		}
-
 		private GameModeSettings _gameModeSettings;
+		private bool _useCurrentOptionsForNextMission;
 	}
 
 	internal class StartMissionThread
 	{
-		public static void ThreadProc(object gameModeSettings)
+		public class StartMissionRequest
 		{
+			public readonly GameModeSettings GameModeSettings;
+			public readonly bool UseCurrentOptionsForNextMission;
+
+			public StartMissionRequest(GameModeSettings gameModeSettings, bool useCurrentOptionsForNextMission)
+			{
+				GameModeSettings = gameModeSettings;
+				UseCurrentOptionsForNextMission = useCurrentOptionsForNextMission;
+			}
+		}
+
+		public static void ThreadProc(object requestObj)
+		{
+			StartMissionRequest request = requestObj as StartMissionRequest;
 			Thread.Sleep(1000);
 			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
-			GameModeStarter.Instance.StartMissionOnly((GameModeSettings)gameModeSettings);
+
+			if (request?.UseCurrentOptionsForNextMission == true)
+			{
+				GameModeSettings nextSettings = GameModeStarter.Instance.CreateSettingsFromCurrentOptions();
+				GameModeStarter.Instance.StartMissionOnly(nextSettings);
+				return;
+			}
+
+			GameModeStarter.Instance.StartMissionOnly(request?.GameModeSettings);
 		}
 
 		public StartMissionThread()

--- a/Alliance.Server/Extensions/NativeIntermissionVote/Behaviors/NativeIntermissionVoteMissionListener.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/Behaviors/NativeIntermissionVoteMissionListener.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote.Behaviors
+{
+	/// <summary>
+	/// Triggers the native intermission vote after mission close, when clients are back in LobbyGameStateCustomGameClient.
+	/// </summary>
+	internal class NativeIntermissionVoteMissionListener : IMissionListener
+	{
+		public void OnEndMission()
+		{
+			Mission.Current?.RemoveListener(this);
+			new Thread(NativeIntermissionVoteService.RunVoteAndRestartMission).Start();
+		}
+
+		public void OnInitialDeploymentPlanMade(BattleSideEnum battleSide, bool isFirstPlan) { }
+		public void OnMissionModeChange(MissionMode oldMissionMode, bool atStart) { }
+		public void OnResetMission() { }
+		public void OnEquipItemsFromSpawnEquipmentBegin(Agent agent, Agent.CreationType creationType) { }
+		public void OnEquipItemsFromSpawnEquipment(Agent agent, Agent.CreationType creationType) { }
+		public void OnConversationCharacterChanged() { }
+		public void OnDeploymentPlanMade(Team team, bool isFirstPlan) { }
+	}
+}
+

--- a/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
@@ -1,0 +1,325 @@
+using Alliance.Common.GameModes;
+using Alliance.Common.GameModes.Story;
+using Alliance.Common.GameModes.Story.Models;
+using Alliance.Server.Core;
+using Alliance.Server.Extensions.NativeIntermissionVote.Behaviors;
+using Alliance.Server.Extensions.NativeIntermissionVote.NetworkMessages;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+using static TaleWorlds.MountAndBlade.MultiplayerOptions;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote
+{
+	/// <summary>
+	/// Handles the custom timeline for looping the current game mode through TaleWorlds native intermission votes.
+	/// </summary>
+	internal static class NativeIntermissionVoteService
+	{
+		private const float MapVoteDurationSeconds = 15f;
+		private const float CultureVoteDurationSeconds = 15f;
+		private const float IntermissionUpdateTickSeconds = 0.5f;
+		private const int WaitForLobbyStateMilliseconds = 2000;
+		private const int WaitBeforeMissionStartMilliseconds = 1000;
+		private const string ScenarioGameType = "Scenario";
+
+		private static readonly List<string> DefaultCultureVotePool = new List<string>
+		{
+			"khuzait",
+			"aserai",
+			"battania",
+			"vlandia",
+			"sturgia",
+			"empire"
+		};
+		private static readonly Dictionary<string, ScenarioVoteCandidate> ScenarioVoteCandidatesByVoteId = new Dictionary<string, ScenarioVoteCandidate>();
+		private static bool _currentVoteIsScenario;
+
+		/// <summary>
+		/// Tries to start the native intermission vote flow.
+		/// Returns false when the flow cannot be prepared and caller should use its fallback transition.
+		/// </summary>
+		internal static bool TryStart(GameModeStarter gameModeStarter, GameModeSettings currentGameModeSettings)
+		{
+			MissionLobbyComponent missionLobby = Mission.Current?.GetMissionBehavior<MissionLobbyComponent>();
+			if (missionLobby == null)
+			{
+				Log("Native intermission loop requested but MissionLobbyComponent is missing.", LogLevel.Warning);
+				return false;
+			}
+
+			if (missionLobby.CurrentMultiplayerState == MissionLobbyComponent.MultiplayerGameState.Ending)
+			{
+				return true;
+			}
+
+			_currentVoteIsScenario = IsScenario(currentGameModeSettings);
+
+			if (!PrepareVote(currentGameModeSettings, _currentVoteIsScenario))
+			{
+				return false;
+			}
+
+			gameModeStarter.EndMissionWithListener(new NativeIntermissionVoteMissionListener());
+			Log("Ending mission — native vote will run after mission closes, when clients are in lobby state.");
+			return true;
+		}
+
+		/// <summary>
+		/// Prepares the native voting manager before mission end, without broadcasting vote items yet.
+		/// Clients receive items only after returning to LobbyGameStateCustomGameClient.
+		/// </summary>
+		private static bool PrepareVote(GameModeSettings currentGameModeSettings, bool isScenarioVote)
+		{
+			if (currentGameModeSettings == null)
+			{
+				Log("Native intermission vote preparation failed: current game mode settings are null.", LogLevel.Error);
+				return false;
+			}
+
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			if (votingManager == null)
+			{
+				Log("Native intermission vote preparation failed: MultiplayerIntermissionVotingManager is missing.", LogLevel.Error);
+				return false;
+			}
+
+			votingManager.InitialGameType = OptionType.GameType.GetStrValue();
+			votingManager.IsAutomatedBattleSwitchingEnabled = true;
+			votingManager.IsMapVoteEnabled = true;
+			votingManager.IsCultureVoteEnabled = !isScenarioVote;
+			votingManager.IsDisableMapVoteOverride = false;
+			votingManager.IsDisableCultureVoteOverride = false;
+			votingManager.IsMapSelectedByAdmin = false;
+
+			return PrepareVoteItems(votingManager, currentGameModeSettings, isScenarioVote);
+		}
+
+
+		/// <summary>
+		/// Runs after the mission has closed. At this point clients are in lobby state and can display the native vote UI.
+		/// </summary>
+		public static void RunVoteAndRestartMission()
+		{
+			// Give clients time to finish mission unload and enter lobby state.
+			Thread.Sleep(WaitForLobbyStateMilliseconds);
+
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			bool isScenarioVote = _currentVoteIsScenario;
+
+			// Re-enable voting and sync native manager values.
+			votingManager.IsMapVoteEnabled = true;
+			votingManager.IsCultureVoteEnabled = !isScenarioVote;
+			NativeIntermissionVoteMsg.SyncVotingManagerValuesToAllPeers();
+
+			NativeIntermissionVoteMsg.SendVoteItemsToAllPeers(votingManager);
+
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMapVote;
+			Log($"Native vote timeline - state -> CountingForMapVote for {MapVoteDurationSeconds}s");
+			RunIntermissionCountdown(MultiplayerIntermissionState.CountingForMapVote, MapVoteDurationSeconds);
+
+			if (!isScenarioVote)
+			{
+				votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForCultureVote;
+				Log($"Native vote timeline - state -> CountingForCultureVote for {CultureVoteDurationSeconds}s");
+				RunIntermissionCountdown(MultiplayerIntermissionState.CountingForCultureVote, CultureVoteDurationSeconds);
+			}
+
+			Log($"Native vote timeline - sorting votes. Maps={votingManager.MapVoteItems.Count} Cultures={votingManager.CultureVoteItems.Count}", LogLevel.Debug);
+			if (isScenarioVote)
+			{
+				StartVotedScenario(votingManager);
+				return;
+			}
+
+			votingManager.SortVotesAndPickBest();
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMission;
+
+			string selectedMap = OptionType.Map.GetStrValue();
+			string selectedCulture1 = OptionType.CultureTeam1.GetStrValue();
+			string selectedCulture2 = OptionType.CultureTeam2.GetStrValue();
+			Log($"Native vote timeline - state -> CountingForMission | selectedMap={selectedMap} | culture1={selectedCulture1} | culture2={selectedCulture2}");
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+
+			GameModeSettings nextSettings = GameModeStarter.Instance.CreateSettingsFromCurrentOptions();
+			nextSettings.TWOptions[OptionType.Map] = selectedMap;
+			nextSettings.TWOptions[OptionType.CultureTeam1] = selectedCulture1;
+			nextSettings.TWOptions[OptionType.CultureTeam2] = selectedCulture2;
+
+			Thread.Sleep(WaitBeforeMissionStartMilliseconds);
+			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+			GameModeStarter.Instance.StartMissionOnly(nextSettings);
+		}
+
+		private static bool PrepareVoteItems(MultiplayerIntermissionVotingManager votingManager, GameModeSettings currentGameModeSettings, bool isScenarioVote)
+		{
+			Log($"Vote setup - gameType={OptionType.GameType.GetStrValue()} | currentState={votingManager.CurrentVoteState} | mapsEnabled={votingManager.IsMapVoteEnabled} | culturesEnabled={votingManager.IsCultureVoteEnabled}", LogLevel.Debug);
+			Log($"Vote setup - current map={OptionType.Map.GetStrValue()} | cultures={OptionType.CultureTeam1.GetStrValue()} vs {OptionType.CultureTeam2.GetStrValue()}", LogLevel.Debug);
+
+			List<string> cultureVotePool = votingManager.CultureVoteItems.Select(item => item.Id).Distinct().ToList();
+			if (cultureVotePool.Count < 3)
+			{
+				cultureVotePool = new List<string>(DefaultCultureVotePool);
+			}
+
+			votingManager.ClearVotes();
+			votingManager.ClearItems();
+			ScenarioVoteCandidatesByVoteId.Clear();
+
+			if (isScenarioVote)
+			{
+				return PrepareScenarioVoteItems(votingManager);
+			}
+
+			List<string> availableMaps = currentGameModeSettings.GetAvailableMaps().Select(scene => scene.Name).Distinct().Take(MultiplayerIntermissionVotingManager.MaxAllowedMapCount).ToList();
+			Log($"Vote setup - preparing {availableMaps.Count} map candidates.", LogLevel.Debug);
+			for (int i = 0; i < availableMaps.Count; i++)
+			{
+				votingManager.MapVoteItems.Add(new IntermissionVoteItem(availableMaps[i], i));
+				Log($"Vote setup - map[{i}]={availableMaps[i]}", LogLevel.Debug);
+			}
+
+			Log($"Vote setup - preparing {cultureVotePool.Count} culture candidates.", LogLevel.Debug);
+			for (int i = 0; i < cultureVotePool.Count; i++)
+			{
+				votingManager.CultureVoteItems.Add(new IntermissionVoteItem(cultureVotePool[i], i));
+				Log($"Vote setup - culture[{i}]={cultureVotePool[i]}", LogLevel.Debug);
+			}
+
+			return availableMaps.Count > 0;
+		}
+
+		private static bool PrepareScenarioVoteItems(MultiplayerIntermissionVotingManager votingManager)
+		{
+			ScenarioManager.Instance.RefreshAvailableScenarios();
+
+			HashSet<string> usedVoteIds = new HashSet<string>();
+			List<Scenario> scenarios = ScenarioManager.Instance.AvailableScenario ?? new List<Scenario>();
+			foreach (Scenario scenario in scenarios)
+			{
+				if (scenario?.Acts == null)
+				{
+					continue;
+				}
+
+				for (int actIndex = 0; actIndex < scenario.Acts.Count; actIndex++)
+				{
+					Act act = scenario.Acts[actIndex];
+					if (act == null || string.IsNullOrEmpty(act.MapID))
+					{
+						continue;
+					}
+
+					string voteId = CreateScenarioVoteId(scenario, act, actIndex, usedVoteIds);
+					int itemIndex = votingManager.MapVoteItems.Count;
+					votingManager.MapVoteItems.Add(new IntermissionVoteItem(voteId, itemIndex));
+					ScenarioVoteCandidatesByVoteId[voteId] = new ScenarioVoteCandidate(scenario, act);
+					Log($"Vote setup - scenario[{itemIndex}]={voteId} | map={act.MapID}", LogLevel.Debug);
+				}
+			}
+
+			Log($"Vote setup - culture vote disabled for Scenario game mode. Prepared {ScenarioVoteCandidatesByVoteId.Count} scenario candidates.", LogLevel.Debug);
+			return ScenarioVoteCandidatesByVoteId.Count > 0;
+		}
+
+		private static string CreateScenarioVoteId(Scenario scenario, Act act, int actIndex, HashSet<string> usedVoteIds)
+		{
+			string baseVoteId = $"{scenario.Name.LocalizedText} - {act.Name.LocalizedText}";
+			if (string.IsNullOrWhiteSpace(baseVoteId) || baseVoteId == " - ")
+			{
+				baseVoteId = $"{scenario.Id} - Act {actIndex + 1}";
+			}
+
+			string voteId = baseVoteId;
+			if (usedVoteIds.Contains(voteId))
+			{
+				voteId = $"{baseVoteId} [{scenario.Id}:{actIndex + 1}]";
+			}
+
+			int duplicateIndex = 2;
+			while (usedVoteIds.Contains(voteId))
+			{
+				voteId = $"{baseVoteId} [{scenario.Id}:{actIndex + 1}:{duplicateIndex++}]";
+			}
+
+			usedVoteIds.Add(voteId);
+			return voteId;
+		}
+
+		private static void StartVotedScenario(MultiplayerIntermissionVotingManager votingManager)
+		{
+			ScenarioVoteCandidate candidate = GetWinningScenarioCandidate(votingManager);
+			if (candidate == null)
+			{
+				Log("Native scenario vote failed: no winning scenario candidate found. Falling back to Lobby.", LogLevel.Error);
+				GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+				GameModeStarter.Instance.StartLobby(OptionType.Map.GetStrValue(), OptionType.CultureTeam1.GetStrValue(), OptionType.CultureTeam2.GetStrValue());
+				return;
+			}
+
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMission;
+			OptionType.Map.SetValue(candidate.Act.MapID);
+			Log($"Native vote timeline - state -> CountingForMission | selectedScenario={candidate.Scenario.Name.LocalizedText} | act={candidate.Act.Name.LocalizedText} | map={candidate.Act.MapID}");
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+
+			Thread.Sleep(WaitBeforeMissionStartMilliseconds);
+			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+			candidate.Act.ActSettings.TWOptions[OptionType.Map] = candidate.Act.MapID;
+			ScenarioManager.Instance.StartScenario(candidate.Scenario, candidate.Act);
+		}
+
+		private static ScenarioVoteCandidate GetWinningScenarioCandidate(MultiplayerIntermissionVotingManager votingManager)
+		{
+			IntermissionVoteItem winningItem = votingManager.MapVoteItems.OrderByDescending(item => item.VoteCount).FirstOrDefault();
+			if (winningItem == null)
+			{
+				return null;
+			}
+
+			if (winningItem.VoteCount <= 0)
+			{
+				winningItem = votingManager.MapVoteItems[MBRandom.RandomInt(0, votingManager.MapVoteItems.Count)];
+			}
+
+			ScenarioVoteCandidatesByVoteId.TryGetValue(winningItem.Id, out ScenarioVoteCandidate candidate);
+			return candidate;
+		}
+
+		private static void RunIntermissionCountdown(MultiplayerIntermissionState state, float durationSeconds)
+		{
+			float remaining = durationSeconds;
+			while (remaining > 0f)
+			{
+				NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(state, remaining);
+				float step = remaining > IntermissionUpdateTickSeconds ? IntermissionUpdateTickSeconds : remaining;
+				Thread.Sleep((int)(step * 1000f));
+				remaining -= step;
+			}
+
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(state, 0f);
+		}
+
+		private static bool IsScenario(GameModeSettings gameModeSettings)
+		{
+			return gameModeSettings?.TWOptions[OptionType.GameType]?.ToString() == ScenarioGameType;
+		}
+
+		private sealed class ScenarioVoteCandidate
+		{
+			public readonly Scenario Scenario;
+			public readonly Act Act;
+
+			public ScenarioVoteCandidate(Scenario scenario, Act act)
+			{
+				Scenario = scenario;
+				Act = act;
+			}
+		}
+	}
+}
+
+
+

--- a/Alliance.Server/Extensions/NativeIntermissionVote/NetworkMessages/NativeIntermissionVoteMsg.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/NetworkMessages/NativeIntermissionVoteMsg.cs
@@ -1,0 +1,98 @@
+using Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer;
+using NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote.NetworkMessages
+{
+	/// <summary>
+	/// Server-side message sender for the native intermission vote UI.
+	/// Uses TaleWorlds native intermission messages, plus one Alliance reset message to rebuild client vote lists safely.
+	/// </summary>
+	internal static class NativeIntermissionVoteMsg
+	{
+		public static void SyncVotingManagerValuesToAllPeers()
+		{
+			SendToAllClients(new UpdateIntermissionVotingManagerValues());
+		}
+
+		public static void SendVoteItemsToAllPeers(MultiplayerIntermissionVotingManager votingManager)
+		{
+			Log($"Vote broadcast - {votingManager.MapVoteItems.Count} maps, {votingManager.CultureVoteItems.Count} cultures.", LogLevel.Debug);
+			ResetVoteItemsOnAllPeers();
+
+			foreach (IntermissionVoteItem item in votingManager.MapVoteItems)
+			{
+				SendMapItemAddedToAllPeers(item.Id);
+				SendMapVoteCountChangedToAllPeers(item.Index, item.VoteCount);
+			}
+
+			foreach (IntermissionVoteItem item in votingManager.CultureVoteItems)
+			{
+				SendCultureItemAddedToAllPeers(item.Id);
+				SendCultureVoteCountChangedToAllPeers(item.Index, item.VoteCount);
+			}
+		}
+
+		public static void SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState state, float timer)
+		{
+			SendToAllClients(new MultiplayerIntermissionUpdate(state, timer));
+		}
+
+		private static void ResetVoteItemsOnAllPeers()
+		{
+			// Native item messages are append-only and vote counts are later updated by index.
+			// CountingForMission makes MPIntermissionVM clear its displayed lists, while the custom
+			// message clears MultiplayerIntermissionVotingManager items on the client.
+			SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+			ClearVoteItemsOnAllPeers();
+		}
+
+		private static void SendMapItemAddedToAllPeers(string mapId)
+		{
+			Log($"Native vote broadcast - map item added: {mapId}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionMapItemAdded(mapId));
+		}
+
+		private static void ClearVoteItemsOnAllPeers()
+		{
+			Log("Native vote broadcast - clearing vote items on clients.", LogLevel.Debug);
+			SendToAllClients(new ClearNativeIntermissionVoteItems());
+		}
+
+		private static void SendCultureItemAddedToAllPeers(string cultureId)
+		{
+			Log($"Native vote broadcast - culture item added: {cultureId}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionCultureItemAdded(cultureId));
+		}
+
+		private static void SendMapVoteCountChangedToAllPeers(int mapItemIndex, int voteCount)
+		{
+			Log($"Native vote broadcast - map vote count changed: index={mapItemIndex} votes={voteCount}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionMapItemVoteCountChanged(mapItemIndex, voteCount));
+		}
+
+		private static void SendCultureVoteCountChangedToAllPeers(int cultureItemIndex, int voteCount)
+		{
+			Log($"Native vote broadcast - culture vote count changed: index={cultureItemIndex} votes={voteCount}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionCultureItemVoteCountChanged(cultureItemIndex, voteCount));
+		}
+
+		private static void SendToAllClients(GameNetworkMessage message)
+		{
+			foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
+			{
+				if (peer.IsServerPeer)
+				{
+					continue;
+				}
+
+				GameNetwork.BeginModuleEventAsServer(peer);
+				GameNetwork.WriteMessage(message);
+				GameNetwork.EndModuleEventAsServer();
+			}
+		}
+	}
+}
+

--- a/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
+++ b/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
@@ -116,7 +116,7 @@ namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 					CommonAdminMsg.SendNotificationToAll(loseMessage);
 					Log(loseMessage);
 				}
-				GameModeStarter.Instance.StartLobby(MultiplayerOptions.OptionType.Map.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+				GameModeStarter.Instance.StartPostMatchTransition();
 				_gameEnded = true;
 			}
 		}

--- a/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
+++ b/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
@@ -828,10 +828,10 @@ namespace Alliance.Server.GameModes.CaptainX.Behaviors
 
 		private void OnPostRoundEnd()
 		{
-			// Go back to Lobby on match end
+			// Start the configured post-match transition
 			if (RoundController.IsMatchEnding)
 			{
-				GameModeStarter.Instance.StartLobby(MultiplayerOptions.OptionType.Map.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+				GameModeStarter.Instance.StartPostMatchTransition();
 			}
 			else if (UseGold())
 			{

--- a/Alliance.Server/GameModes/Story/Actions/Server_ActionFactory.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_ActionFactory.cs
@@ -24,6 +24,11 @@ namespace Alliance.Server.GameModes.Story.Actions
 			return new Server_StartScenarioAction();
 		}
 
+		public override EndScenarioAction EndScenarioAction()
+		{
+			return new Server_EndScenarioAction();
+		}
+
 		public override SpawnAgentAction SpawnAgentAction()
 		{
 			return new Server_SpawnAgentAction();

--- a/Alliance.Server/GameModes/Story/Actions/Server_EndScenarioAction.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_EndScenarioAction.cs
@@ -1,0 +1,18 @@
+using Alliance.Common.GameModes.Story.Actions;
+using Alliance.Server.Core;
+
+namespace Alliance.Server.GameModes.Story.Actions
+{
+	/// <summary>
+	/// Server-side implementation for ending a scenario and starting the configured post-match transition.
+	/// </summary>
+	public class Server_EndScenarioAction : EndScenarioAction
+	{
+		public override void Execute()
+		{
+			GameModeStarter.Instance.StartPostMatchTransition();
+		}
+	}
+}
+
+

--- a/Alliance.Server/GameModes/Story/ScenarioManagerServer.cs
+++ b/Alliance.Server/GameModes/Story/ScenarioManagerServer.cs
@@ -31,7 +31,7 @@ namespace Alliance.Server.GameModes.Story
 			{
 				Act currentAct = currentScenario.Acts[actIndex];
 				StartScenario(currentScenario, currentAct, state);
-				Log($"Starting scenario \"{currentScenario?.Name.LocalizedText}\" at act {actIndex + 1}", LogLevel.Debug);
+				Log($"Starting scenario \"{currentScenario.Name.LocalizedText}\" at act {actIndex + 1}", LogLevel.Debug);
 			}
 			else
 			{
@@ -44,14 +44,18 @@ namespace Alliance.Server.GameModes.Story
 			base.StartScenario(scenario, act, state);
 
 			// If LoadMap enabled or current map is different from act map, start a complete new mission with act settings
-			if (act.LoadMap || (act.MapID != null && OptionType.Map.GetValueText() != act.MapID))
+			if (Mission.Current == null || act.LoadMap || (act.MapID != null && OptionType.Map.GetValueText() != act.MapID))
 			{
 				// If currently in a Scenario, prevent it from changing state
-				Mission.Current.GetMissionBehavior<ScenarioBehavior>()?.StopScenario();
+				Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.StopScenario();
+				if (act.MapID != null)
+				{
+					act.ActSettings.TWOptions[OptionType.Map] = act.MapID;
+				}
 
 				// Log the start
 				string log2 = $"Starting scenario \"{scenario.Name.LocalizedText}\" - Act \"{act.Name.LocalizedText}\" on map {act.MapID}...";
-				Log(log2, LogLevel.Information);
+				Log(log2);
 				SendMessageToAll(log2);
 				GameModeStarter.Instance.StartMission(act.ActSettings);
 				return;
@@ -59,7 +63,7 @@ namespace Alliance.Server.GameModes.Story
 
 			// Log the start
 			string log = $"Starting scenario \"{scenario.Name.LocalizedText}\" - Act \"{act.Name.LocalizedText}\"...";
-			Log(log, LogLevel.Information);
+			Log(log);
 			SendMessageToAll(log);
 
 			// Else, just apply new act settings to the current mission
@@ -91,7 +95,7 @@ namespace Alliance.Server.GameModes.Story
 		/// </summary>
 		public void SyncActState(ActState newState)
 		{
-			float stateRemainingTime = (float)(Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.TimerComponent.GetRemainingTime(false));
+			float stateRemainingTime = Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.TimerComponent.GetRemainingTime(false) ?? 0f;
 			GameNetwork.BeginBroadcastModuleEvent();
 			GameNetwork.WriteMessage(new UpdateScenarioMessage(newState, MissionTime.Now.NumberOfTicks, MathF.Ceiling(stateRemainingTime)));
 			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);


### PR DESCRIPTION
# Native post-match intermission voting

## Summary

Adds an optional post-match flow using TaleWorlds native intermission voting. When `LoopCurrentModeWithNativeVote` is enabled, the server can keep the current game mode running and let players vote for the next map and, when applicable, cultures. If the vote flow cannot start, the server falls back to the existing Lobby transition.

## Changes

- Added `LoopCurrentModeWithNativeVote` advanced config option.
- Added `GameModeStarter.StartPostMatchTransition()` and updated BR/CaptainX match-end logic to use it.
- Added the `NativeIntermissionVote` server extension to prepare vote items, run the intermission timeline, broadcast native vote messages, and restart the selected game mode.
- Added a client-side reset message/handler to clear stale native vote items before broadcasting custom vote candidates.
- Added special handling for `Scenario` mode:
  - map vote only;
  - culture vote disabled;
  - vote candidates represent `Scenario + Act`, not only physical maps, because several scenarios can share the same `MapID`.
- Added `EndScenarioAction`, allowing scenarios to explicitly trigger the configured post-match transition.
- Updated `ScenarioManagerServer` to better support starting scenarios from intermission/lobby state.
- Added `.github/agents/tw-native-explorer.agent.md` to help explore decompiled TaleWorlds native code.

## Scenario migration note

Existing scenarios that should use this new post-match flow need to add `EndScenarioAction` to the relevant `ActionsOnActCompleted` list.

Without this action, existing scenario completion remains action-driven and will not automatically start the new vote/lobby transition.