### PR TITLE
[New feature] Native post-match intermission voting

### DIFF
--- a/.github/agents/tw-native-explorer.agent.md
+++ b/.github/agents/tw-native-explorer.agent.md
@@ -1,0 +1,103 @@
+---
+name: tw-native-explorer
+description: >
+  Specialist in searching and reading decompiled native TaleWorlds (Bannerlord) code.
+  Explores, locates and analyzes classes, methods and types from the TaleWorlds engine
+  using the decompiled source code available under Alliance.Common/TW_References/BannerlordSource/.
+tools:
+  - run_in_terminal   # PowerShell searches in BannerlordSource (required — replaces grep_search/file_search)
+  - read_file         # Read located .cs files
+  - list_dir          # Navigate the BannerlordSource directory tree
+---
+
+You are an expert agent for exploring native TaleWorlds (Mount & Blade II: Bannerlord) code.
+You specialize in searching, reading and analyzing the decompiled source code of TaleWorlds
+assemblies, available under:
+  `Alliance.Common/TW_References/BannerlordSource/`
+
+## Hard scope restriction (MANDATORY)
+
+You are strictly limited to this directory and its children only:
+`Alliance.Common/TW_References/BannerlordSource/`
+
+Before using any tool (`run_in_terminal`, `read_file`, `list_dir`), ensure the target path is inside
+`Alliance.Common/TW_References/BannerlordSource/`.
+
+If a request points to any other location in the repository, refuse and state that the request is out of scope for this agent.
+
+## Decompiled source structure
+
+The BannerlordSource folder is organized by namespace/assembly, for example:
+
+| Path | Assembly |
+|---|---|
+| `TaleWorlds/MountAndBlade/` | TaleWorlds.MountAndBlade.dll (core gameplay) |
+| `TaleWorlds/MountAndBlade/Multiplayer/` | TaleWorlds.MountAndBlade.Multiplayer.dll |
+| `TaleWorlds/Core/` | TaleWorlds.Core.dll |
+| `TaleWorlds/Engine/` | TaleWorlds.Engine.dll |
+| `TaleWorlds/Library/` | TaleWorlds.Library.dll |
+| `TaleWorlds/CampaignSystem/` | TaleWorlds.CampaignSystem.dll |
+| `Sandbox/` | SandBox.dll |
+| `Storymode/` | StoryMode.dll |
+
+## Search strategy
+
+> ⚠️ **IMPORTANT**: Do **NOT** use `grep_search` or `file_search` tools to search in `BannerlordSource/`.
+> These tools rely on workspace indexing, and `BannerlordSource/` is excluded from the index (listed in `.gitignore`).
+> They will return no results even when files exist on disk.
+> **Always use terminal commands (PowerShell) instead.**
+>
+> You must run searches only inside:
+> `Alliance.Common/TW_References/BannerlordSource/`
+
+Use the following PowerShell command pattern to search for a type or symbol:
+
+```powershell
+Get-ChildItem -Path "XXXX\Alliance\Alliance.Common\TW_References\BannerlordSource" -Recurse -Filter "*.cs" | Select-String -Pattern "SymbolName" -List
+```
+
+Replace `XXXX` with the actual path to the workspace root, and `SymbolName` with the class, method, or pattern to search for.
+
+1. Always start by running a PowerShell search against `BannerlordSource/` using the command above.
+2. Use the namespace hierarchy to navigate efficiently once the file is located.
+3. Read the relevant `.cs` files to understand signatures, inheritance and behaviors.
+4. Cross-reference multiple files when needed (e.g. base class + derived class).
+5. Report information concisely: full signature, inheritance chain, important members.
+6. Do not inspect any file outside `BannerlordSource/`.
+
+## If the source code is missing or incomplete
+
+If `BannerlordSource/` is empty, missing, or if searched files cannot be found,
+clearly state it and propose the following actions in priority order:
+
+1. **ILSpy not installed?** → Run first:
+   `Alliance.Common/TW_References/Install ILSpy.bat`
+   (installs ilspycmd via dotnet tool: `dotnet tool install --global ilspycmd --version 8.0.0.7246-preview3`)
+
+2. **Generate the source code** → Then run:
+   `Alliance.Common/TW_References/Decompile.bat`
+   (decompiles all TaleWorlds DLLs into BannerlordSource/ — requires `BANNERLORD_GAME_DIR`)
+
+3. **PDB files for debugging** → Only if needed for crash debugging:
+   `Alliance.Common/TW_References/GenPDB.bat`
+   (generates `.pdb` files and copies them to the game directory)
+
+> ⚠️ **IMPORTANT**: These operations are time-consuming and resource-intensive.
+> Only suggest them if files are genuinely not found after searching `BannerlordSource/`.
+> **NEVER** run these scripts automatically — always require explicit user confirmation.
+
+## What you must provide
+
+- Exact file location (relative path from the workspace root)
+- Full signature of the searched types/methods
+- Inheritance hierarchy when relevant
+- Contextual code excerpts (key methods, important properties)
+- Usage patterns observed in the native code
+
+## What you must NOT do
+
+- Invent or assume native code not present in `BannerlordSource/`
+- Read, list, or search files outside `Alliance.Common/TW_References/BannerlordSource/`
+- Run terminal commands that target paths outside `Alliance.Common/TW_References/BannerlordSource/`
+- Modify any files in `TW_References/` or `BannerlordSource/`
+- Run `Decompile.bat`, `GenPDB.bat` or `Install ILSpy.bat` without explicit user confirmation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Alliance – AI Agent Guide
+
+## Project Overview
+Alliance is a multiplayer mod for **Mount & Blade II: Bannerlord** (TaleWorlds engine).  
+It is a C# solution with five projects that map to distinct Bannerlord deployment targets.
+
+| Project | Target | Role |
+|---|---|---|
+| `Alliance.Common` | `net472` + `net6.0` | Shared code: config, network messages, base behaviors, extensions |
+| `Alliance.Client` | `net472` | Client-only: views, UI, client-side behaviors |
+| `Alliance.Server` | `net6.0` | Dedicated server: server behaviors, admin, persistence |
+| `Alliance.Editor` | `net472` | Bannerlord editor tools |
+| `Alliance.SP` | `net472` | Singleplayer entry point |
+
+## Build System
+- **Prerequisite**: Set environment variable `BANNERLORD_GAME_DIR` to your Bannerlord installation path before building.
+- Build any project via `dotnet build` or Visual Studio. The post-build event automatically copies DLLs and module assets to `%BANNERLORD_GAME_DIR%/Modules/Alliance/`.
+- `Alliance.Common` compiles twice: `net472` (client) and `net6.0` (server). The constant `SERVER` is defined only for `net6.0`, enabling `#if SERVER` guards in shared code.
+- Version is centralized in `Alliance.Common/CommonProps.props` (`AllianceVersion`). `SubModule.xml` version is updated automatically on build.
+- To decompile TaleWorlds source for reference: run `Alliance.Common/TW_References/Decompile.bat` (requires ILSpy via `Install ILSpy.bat`). Output lands in `TW_References/BannerlordSource/`.
+
+## Adding a New Game Mode
+Every game mode is registered symmetrically on Client and Server. Follow this checklist:
+1. **Common**: Add a folder under `Alliance.Common/GameModes/<Name>/` with `Behaviors/`, `NetworkMessages/FromServer/`, `NetworkMessages/FromClient/`, and `Models/`.
+2. **Client**: Add `Alliance.Client/GameModes/<Name>/` with `<Name>GameMode.cs`, views, and a `Handlers/` folder for `IHandlerRegister` implementations.
+3. **Server**: Add `Alliance.Server/GameModes/<Name>/` with the same structure plus `Behaviors/` server logic.
+4. **Registration**: Register the game mode in both `Alliance.Client/SubModule.cs` and `Alliance.Server/SubModule.cs`:
+   ```csharp
+   Module.CurrentModule.AddMultiplayerGameMode(new MyGameMode("MyModeName"));
+   ```
+   The string name must match on both sides.
+5. **Default behaviors**: Use `DefaultClientBehaviors.GetDefaultBehaviors(scoreboardData)` / `DefaultServerBehaviors.GetDefaultBehaviors(scoreboardData)` as base lists, then `.AppendList(...)` custom behaviors.
+
+## Network Messages
+All custom messages live in `Common/.../NetworkMessages/FromServer/` or `FromClient/`.
+
+```csharp
+[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+public sealed class MyMessage : GameNetworkMessage
+{
+    public int Value { get; private set; }
+    public MyMessage() { }
+    public MyMessage(int value) { Value = value; }
+
+    protected override void OnWrite() =>
+        WriteIntToPacket(Value, new CompressionInfo.Integer(0, 100, true));
+
+    protected override bool OnRead()
+    {
+        bool valid = true;
+        Value = ReadIntFromPacket(new CompressionInfo.Integer(0, 100, true), ref valid);
+        return valid;
+    }
+    protected override MultiplayerMessageFilter OnGetLogFilter() => MultiplayerMessageFilter.Mission;
+    protected override string OnGetLogFormat() => "My message";
+}
+```
+
+**Sending** (server → all clients):
+```csharp
+GameNetwork.BeginBroadcastModuleEvent();
+GameNetwork.WriteMessage(new MyMessage(42));
+GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+```
+
+## Registering Message Handlers
+Implement `IHandlerRegister` (defined in `Alliance.Common/Extensions/IHandlerRegister.cs`) in a dedicated handler class — **not** directly on a `MissionBehavior`. `ClientAutoHandler` discovers all implementations via reflection at startup.
+
+```csharp
+public class MyHandler : IHandlerRegister
+{
+    public void Register(GameNetwork.NetworkMessageHandlerRegisterer reg)
+    {
+        reg.Register<MyMessage>(HandleMyMessage);
+    }
+    private void HandleMyMessage(MyMessage msg) { ... }
+}
+```
+
+## Configuration System
+- All mod settings are public fields in `Alliance.Common/Core/Configuration/Models/DefaultConfig.cs` decorated with `[ConfigProperty]`.
+- Access settings via the singleton `Config.Instance.<FieldName>` (available on both client and server).
+- `ConfigManager.Instance` handles validation, serialization, and network sync (`SyncConfigField`, `SendConfigToAllPeers`).
+
+## Harmony Patches
+Patches are organized as `Patch/<DirtyXxxPatcher.cs>` (orchestrators) and `Patch/HarmonyPatch/Patch_<ClassName>.cs` (individual patches).  
+Each patch class exposes a static `Patch()` method returning `bool` and uses its own `Harmony` instance keyed by `SubModule.ModuleId + nameof(PatchClass)`.  
+Patches are a last resort — leave a comment explaining why a clean override was not possible.
+
+## Logging
+Import `static Alliance.Common.Utilities.Logger` and call:
+```csharp
+Log("Message", LogLevel.Debug);   // suppressed in Release builds
+Log("Warning", LogLevel.Warning);
+```
+`LogLevel.Debug` logs are stripped from Release builds. On the server, output goes to the console; on the client, it appears in-game chat.
+
+## Key Files & Directories
+- `Alliance.Common/Core/Configuration/Models/DefaultConfig.cs` – all configurable settings
+- `Alliance.Common/Extensions/IHandlerRegister.cs` – network handler registration contract
+- `Alliance.Client/GameModes/DefaultClientBehaviors.cs` – default client behavior list
+- `Alliance.Server/GameModes/DefaultServerBehaviors.cs` – default server behavior list
+- `Alliance.Common/Patch/DirtyCommonPatcher.cs` – native compression limit overrides
+- `Alliance.Common/TW_References/` – scripts to decompile TaleWorlds source for IDE reference
+- `Alliance.Common/TW_References/BannerlordSource/` – decompiled source code of TaleWorlds DLLs (generated by Decompile.bat)
+- `Alliance.Common/_Module/` – shared assets (GUI, ModuleData, Prefabs, Scenarios…) copied to game at build time
+
+## Custom Agents
+
+### `tw-native-explorer` — TaleWorlds Native Code Explorer
+**Definition file**: `.github/agents/tw-native-explorer.agent.md`
+
+This agent specializes in **searching and reading decompiled native TaleWorlds** (Bannerlord) code.  
+Use it whenever you need to:
+- Understand the behavior of a native TaleWorlds class/method
+- Find the inheritance hierarchy of an engine type
+- Identify possible overrides before writing a Harmony patch
+- Explore usage patterns in the native code
+
+**Source of truth**: `Alliance.Common/TW_References/BannerlordSource/`  
+Organized by namespace/assembly (e.g. `TaleWorlds/MountAndBlade/`, `TaleWorlds/Core/`, `Sandbox/`…)
+
+**Authorized tools**: `run_in_terminal`, `read_file`, `list_dir`  
+**Disabled tools**: `grep_search`, `file_search` — `BannerlordSource/` is excluded from the workspace index (`.gitignore`), so these tools return no results. The agent uses PowerShell commands via `run_in_terminal` instead:
+```powershell
+Get-ChildItem -Path "<workspace>\Alliance.Common\TW_References\BannerlordSource" -Recurse -Filter "*.cs" | Select-String -Pattern "SymbolName" -List
+```
+
+**If the source code is missing or incomplete**, the agent will propose in order:
+1. Install ILSpy: `Alliance.Common/TW_References/Install ILSpy.bat`
+2. Decompile the DLLs: `Alliance.Common/TW_References/Decompile.bat` (requires `BANNERLORD_GAME_DIR`)
+3. Generate PDB files (debug only): `Alliance.Common/TW_References/GenPDB.bat`
+
+> ⚠️ These operations are costly — the agent never runs them without explicit user confirmation.

--- a/Alliance.Client/Core/ClientGlobalAutoHandler.cs
+++ b/Alliance.Client/Core/ClientGlobalAutoHandler.cs
@@ -1,0 +1,57 @@
+using Alliance.Common.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using static Alliance.Common.Utilities.Logger;
+using static TaleWorlds.MountAndBlade.GameNetwork;
+
+namespace Alliance.Client.Core
+{
+    /// <summary>
+    /// Discovers and registers all IGlobalHandlerRegister implementations once per game session.
+    /// Unlike ClientAutoHandler, this is not tied to the mission lifecycle (not a MissionBehavior):
+    /// handlers registered here remain active even after mission behaviors are removed
+    /// (e.g. native post-mission intermission voting).
+    /// Call Initialize() once, typically from SubModule.OnGameInitializationFinished.
+    /// </summary>
+    public static class ClientGlobalAutoHandler
+    {
+        private static bool _initialized;
+
+        public static void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            try
+            {
+                NetworkMessageHandlerRegisterer reg = new NetworkMessageHandlerRegisterer(NetworkMessageHandlerRegisterer.RegisterMode.Add);
+                int handlerCount = 0;
+                IEnumerable<Type> handlerTypes = Assembly.GetExecutingAssembly()
+                                           .GetTypes()
+                                           .Where(t => t.GetInterfaces().Contains(typeof(IGlobalHandlerRegister)) && !t.IsAbstract);
+
+                foreach (Type type in handlerTypes)
+                {
+                    if (Activator.CreateInstance(type) is IGlobalHandlerRegister handler)
+                    {
+                        handler.Register(reg);
+                        handlerCount++;
+                    }
+                }
+
+                _initialized = true;
+                Log($"Alliance - Successfully registered {handlerCount} global client handlers", LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                Log($"Alliance - Error while registering global client handlers", LogLevel.Error);
+                Log(ex.ToString(), LogLevel.Error);
+            }
+        }
+    }
+}
+

--- a/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
+++ b/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
@@ -1,0 +1,43 @@
+using Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Client.Extensions.NativeIntermissionVote.Handlers
+{
+	/// <summary>
+	/// Handles client-side synchronization required by Alliance custom native intermission vote flows.
+	/// Registered globally because native intermission voting runs after mission behaviors are removed.
+	/// </summary>
+	internal static class NativeIntermissionVoteHandler
+	{
+		private static bool _registered;
+
+		public static void Register()
+		{
+			if (_registered)
+			{
+				return;
+			}
+
+			GameNetwork.NetworkMessageHandlerRegisterer reg = new GameNetwork.NetworkMessageHandlerRegisterer(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Add);
+			reg.Register<ClearNativeIntermissionVoteItems>(HandleClearNativeIntermissionVoteItems);
+			_registered = true;
+		}
+
+		private static void HandleClearNativeIntermissionVoteItems(ClearNativeIntermissionVoteItems message)
+		{
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			if (votingManager == null)
+			{
+				Log("Failed to clear native intermission vote items: MultiplayerIntermissionVotingManager is missing.", LogLevel.Warning);
+				return;
+			}
+
+			votingManager.ClearVotes();
+			votingManager.ClearItems();
+			Log("Native intermission vote items cleared on client.", LogLevel.Debug);
+		}
+	}
+}
+
+

--- a/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
+++ b/Alliance.Client/Extensions/NativeIntermissionVote/Handlers/NativeIntermissionVoteHandler.cs
@@ -1,3 +1,4 @@
+using Alliance.Common.Extensions;
 using Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer;
 using TaleWorlds.MountAndBlade;
 using static Alliance.Common.Utilities.Logger;
@@ -6,25 +7,18 @@ namespace Alliance.Client.Extensions.NativeIntermissionVote.Handlers
 {
 	/// <summary>
 	/// Handles client-side synchronization required by Alliance custom native intermission vote flows.
-	/// Registered globally because native intermission voting runs after mission behaviors are removed.
+	/// Implements IGlobalHandlerRegister (not IHandlerRegister) and is discovered/registered by
+	/// ClientGlobalAutoHandler, because native intermission voting runs after mission behaviors
+	/// (and thus ClientAutoHandler) have been removed.
 	/// </summary>
-	internal static class NativeIntermissionVoteHandler
+	internal class NativeIntermissionVoteHandler : IGlobalHandlerRegister
 	{
-		private static bool _registered;
-
-		public static void Register()
+		public void Register(GameNetwork.NetworkMessageHandlerRegisterer reg)
 		{
-			if (_registered)
-			{
-				return;
-			}
-
-			GameNetwork.NetworkMessageHandlerRegisterer reg = new GameNetwork.NetworkMessageHandlerRegisterer(GameNetwork.NetworkMessageHandlerRegisterer.RegisterMode.Add);
 			reg.Register<ClearNativeIntermissionVoteItems>(HandleClearNativeIntermissionVoteItems);
-			_registered = true;
 		}
 
-		private static void HandleClearNativeIntermissionVoteItems(ClearNativeIntermissionVoteItems message)
+		private void HandleClearNativeIntermissionVoteItems(ClearNativeIntermissionVoteItems message)
 		{
 			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
 			if (votingManager == null)

--- a/Alliance.Client/SubModule.cs
+++ b/Alliance.Client/SubModule.cs
@@ -1,4 +1,5 @@
 ﻿using Alliance.Client.Core.Providers;
+using Alliance.Client.Extensions.NativeIntermissionVote.Handlers;
 using Alliance.Client.GameModes.BattleRoyale;
 using Alliance.Client.GameModes.BattleX;
 using Alliance.Client.GameModes.CaptainX;
@@ -73,6 +74,7 @@ namespace Alliance.Client
 
 			SceneList.Initialize();
 			ScenarioPlayer.Initialize();
+			NativeIntermissionVoteHandler.Register();
 		}
 
 		private void AddGameModes()

--- a/Alliance.Client/SubModule.cs
+++ b/Alliance.Client/SubModule.cs
@@ -18,6 +18,7 @@ using Alliance.Common.Patch;
 using Alliance.Common.Utilities;
 using System.Collections.Generic;
 using System.Reflection;
+using Alliance.Client.Core;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.ViewModelCollection.Order.Visual;
@@ -74,7 +75,7 @@ namespace Alliance.Client
 
 			SceneList.Initialize();
 			ScenarioPlayer.Initialize();
-			NativeIntermissionVoteHandler.Register();
+			ClientGlobalAutoHandler.Initialize();
 		}
 
 		private void AddGameModes()

--- a/Alliance.Client/_Module/GUI/Prefabs/MultiplayerIntermission.xml
+++ b/Alliance.Client/_Module/GUI/Prefabs/MultiplayerIntermission.xml
@@ -1,0 +1,187 @@
+<Prefab>
+  <Variables>
+  </Variables>
+  <VisualDefinitions>
+  </VisualDefinitions>
+  <Constants>
+    <Constant Name="Banner.Width" BrushName="MPTeamSelection.Banner.Left" BrushLayer="Default" BrushValueType="Width"/>
+    <Constant Name="Banner.Height" BrushName="MPTeamSelection.Banner.Left" BrushLayer="Default" BrushValueType="Height"/>
+  </Constants>
+  <Window>
+    <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent">
+      <Children>
+        <Standard.Background />
+        <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" IsVisible="@IsNextMapInfoEnabled">
+          <Children>
+            <!-- Next Map Image -->
+            <MultiplayerIntermissionNextMapImageWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MapID="@NextMapID"/>
+            <!-- Overlay -->
+            <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Sprite="MPIntermission\intermission_screen_band_effect" AlphaFactor="0.9" />
+          </Children>
+        </Widget>
+        
+        <!-- Top Panel -->
+        <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="180" MarginLeft="30" MarginRight="30" MarginTop="30">
+          <Children>
+            
+            <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Left" VerticalAlignment="Top" StackLayout.LayoutMethod="VerticalTopToBottom" IsVisible="@IsNextMapInfoEnabled">
+              <Children>
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPIntermission.Label.Text" Text="@NextMapName" />
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPIntermission.Value.Text" Text="@NextGameType" MarginTop="10" />
+              </Children>
+            </ListPanel>
+            
+            <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Top" StackLayout.LayoutMethod="VerticalTopToBottom">
+              <Children>
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Label.Text" Text="@NextGameStateTimerLabel" />
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Value.Text" Brush.FontSize="50" Text="@NextGameStateTimerValue" />
+              </Children>
+            </ListPanel>
+            
+            <!-- Leave Button -->
+            <NavigationScopeTargeter ScopeID="LeaveButtonScope" ScopeParent="..\LeaveButtonParent" />
+            <ListPanel Id="LeaveButtonParent" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Right" VerticalAlignment="Top" StackLayout.LayoutMethod="VerticalTopToBottom">
+              <Children>
+                <ButtonWidget Command.Click="ExecuteQuitServer" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="75" SuggestedHeight="75" HorizontalAlignment="Center" Brush="MPIntermission.Leave.Button" MarginBottom="10" GamepadNavigationIndex="0" />
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Leave.Text" Text="@QuitText"/>
+              </Children>
+            </ListPanel>
+        
+          </Children>
+        </Widget>
+        <!-- Banners -->
+        <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Top" HorizontalAlignment="Center" PositionYOffset="210" MarginLeft="18" MarginRight="18">
+          <Children>
+            <!-- Attacker Side -->
+            <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!Banner.Width" SuggestedHeight="!Banner.Height" HorizontalAlignment="Left" VerticalAlignment="Center" IsVisible="@IsFactionAValid">
+              <Children>
+                <MultiplayerFactionBannerWidget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" FactionCode="@NextFactionACultureID" BannerWidget="Banner" IconWidget="Icon" CultureColor1="@NextFactionACultureColor1" CultureColor2="@NextFactionACultureColor2">
+                  <Children>
+                    <BrushWidget Id="Banner" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="MPIntermission.Banner.Left"/>
+                    <BannerWidget DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" CultureID="@NextFactionACultureID" Brush="ButtonSimpleBrush"/>
+                    <Widget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="220" SuggestedHeight="220" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                  </Children>
+                </MultiplayerFactionBannerWidget>
+              </Children>
+            </Widget>
+
+            <!-- Defender Side -->            
+            <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="!Banner.Width" SuggestedHeight="!Banner.Height" HorizontalAlignment="Right" VerticalAlignment="Center" IsVisible="@IsFactionBValid">
+              <Children>
+                <MultiplayerFactionBannerWidget UpdateChildrenStates="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" FactionCode="@NextFactionBCultureID" BannerWidget="Banner" IconWidget="Icon" CultureColor1="@NextFactionBCultureColor1" CultureColor2="@NextFactionBCultureColor2">
+                  <Children>
+                    <BrushWidget Id="Banner" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Brush="MPIntermission.Banner.Right"/>
+                    <BannerWidget DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" CultureID="@NextFactionBCultureID" Brush="ButtonSimpleBrush"/>
+                    <Widget Id="Icon" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="220" SuggestedHeight="220" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                  </Children>
+                </MultiplayerFactionBannerWidget>
+              </Children>
+            </Widget>
+            
+          </Children>
+        </Widget>
+        
+        <!-- Map Vote List -->
+        <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Center" MarginBottom="70" IsVisible="@IsMapVoteEnabled">
+          <Children>
+            <!-- Title Text -->
+            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginTop="20" Brush="MPIntermission.Voting.Title.Text" Brush.FontSize="40" Text="@MapVoteText" />
+
+            <ScrollablePanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginTop="90" MarginBottom="20" AutoHideScrollBars="true" ClipRect="ClipRect" InnerPanel="ClipRect\AvailableMaps" VerticalScrollbar="VerticalScrollbar">
+              <Children>
+                <Widget Id="ClipRect" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MaxHeight="650" ClipContents="true">
+                  <Children>
+                    <NavigationScopeTargeter ScopeID="IntermissionMapSelectionScope" ScopeParent="..\AvailableMaps" ScopeMovements="Horizontal" AlternateScopeMovements="Vertical" AlternateMovementStepSize="5" />
+                    <NavigatableGridWidget Id="AvailableMaps" DataSource="{AvailableMaps}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" UseDynamicCellWidth="true" UseDynamicCellHeight="true" ColumnCount="5">
+                      <ItemTemplate>
+                        <!-- Single Map Item -->
+                        <ListPanel WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="320" MarginLeft="15" MarginRight="15" MarginBottom="30" StackLayout.LayoutMethod="VerticalTopToBottom">
+                          <Children>
+
+                            <NavigationTargetSwitcher FromTarget="..\." ToTarget="..\SelectButton" />
+                            <!-- Map Name -->
+                            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" MarginTop="10" HorizontalAlignment="Center" Brush="MPIntermission.Voting.Title.Text" Brush.FontColor="#F4E1C4FF" Brush.FontSize="28" Text="@MapName" />
+                            <!-- Map Thumbnail Border -->
+                            <ButtonWidget Id="SelectButton" DoNotPassEventsToChildren="true" ButtonType="Radio" IsSelected="@IsSelected" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="320" SuggestedHeight="180" VerticalAlignment="Center" MarginTop="5" Brush="MPIntermission.Map.Button" Command.Click="ExecuteVote" UpdateChildrenStates="true">
+                              <Children>
+                                <MultiplayerIntermissionNextMapImageWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" MarginLeft="3" MarginRight="3" MarginTop="3" MarginBottom="3" MapID="@MapID"/>
+                              </Children>
+                            </ButtonWidget>
+                            <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginTop="10" StackLayout.LayoutMethod="HorizontalLeftToRight">
+                              <Children>
+                                <!-- Vote Icon -->
+                                <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="30" SuggestedHeight="34" Sprite="MPIntermission\thumb" Color="#CD7B3AFF" />
+                                <!-- Vote Count -->
+                                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" MarginLeft="10" Brush="MPIntermission.Voted.Count.Text" Brush.FontSize="48" IntText="@Votes" />
+                              </Children>
+                            </ListPanel>
+                          </Children>
+                        </ListPanel>
+                      </ItemTemplate>
+                    </NavigatableGridWidget>
+                  </Children>
+                </Widget>
+
+                <ScrollbarWidget Id="VerticalScrollbar" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="10" SuggestedHeight="650" HorizontalAlignment="Right" MarginRight="50" AlignmentAxis="Vertical" DoNotUpdateHandleSize="true" Handle="ScrollbarHandle" MaxValue="100" MinValue="0" UpdateChildrenStates="true">
+                  <Children>
+                    <ImageWidget Id="ScrollbarBed" WidthSizePolicy="Fixed" HeightSizePolicy="StretchToParent" SuggestedWidth="4" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPIntermission.Scrollbar.Bed" />
+                    <ImageWidget Id="ScrollbarHandle" WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" HorizontalAlignment="Center" VerticalAlignment="Center" Brush="MPIntermission.Scrollbar.Handle" />
+                  </Children>
+                </ScrollbarWidget>
+              </Children>
+            </ScrollablePanel>
+          </Children>
+        </Widget>
+
+        <!-- Culture Vote List -->
+        <Widget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Center" MarginBottom="100" IsVisible="@IsCultureVoteEnabled">
+          <Children>
+            <!-- Title Text -->
+            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginTop="20" Brush="MPIntermission.Voting.Title.Text" Brush.FontSize="40" Text="@CultureVoteText" />
+            <ListPanel DataSource="{AvailableCultures}" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginTop="90" MarginBottom="20" StackLayout.LayoutMethod="HorizontalLeftToRight">
+              <ItemTemplate>
+                <!-- Single Culture Item -->
+                <ListPanel WidthSizePolicy="Fixed" HeightSizePolicy="CoverChildren" SuggestedWidth="140" MarginLeft="50" MarginRight="50" StackLayout.LayoutMethod="VerticalTopToBottom">
+                  <Children>
+        
+                    <!-- Culture Sigil -->
+                    <!-- Display nothing in this native widget (transparent brush) -->
+                    <MultiplayerLobbyClassFilterFactionItemButtonWidget ButtonType="Radio" IsSelected="@IsSelected" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="214" SuggestedHeight="251" HorizontalAlignment="Center" Command.Click="ExecuteVote" Brush="Alliance.TransparentBrush">
+                      <Children>
+                        <HintWidget DataSource="{Hint}" DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint" />
+                        <!-- Display faction icon using our custom BannerWidget -->
+                        <BannerWidget DoNotAcceptEvents="true" WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" CultureID="@CultureCode" Brush="ButtonSimpleBrush"/>
+                      </Children>
+                    </MultiplayerLobbyClassFilterFactionItemButtonWidget>
+                    <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" MarginTop="10" StackLayout.LayoutMethod="HorizontalLeftToRight">
+                      <Children>
+                        <!-- Vote Icon -->
+                        <Widget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="30" SuggestedHeight="34" Sprite="MPIntermission\thumb" Color="#CD7B3AFF" />
+                        <!-- Vote Count -->
+                        <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" VerticalAlignment="Bottom" MarginLeft="10" Brush="MPIntermission.Voted.Count.Text" Brush.FontSize="48" IntText="@Votes" />
+                      </Children>
+                    </ListPanel>
+                  </Children>
+                </ListPanel>
+              </ItemTemplate>
+            </ListPanel>
+          </Children>
+        </Widget>
+
+        <!-- Connected Players -->
+        <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" VerticalAlignment="Bottom" StackLayout.LayoutMethod="VerticalTopToBottom" MarginBottom="25" MarginLeft="50" MarginRight="50" IsVisible="@IsPlayerCountEnabled">
+          <Children>
+            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Voting.Title.Text" Brush.FontSize="42" Text="@PlayersLabel" MarginBottom="15" />
+            <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+              <Children>
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPIntermission.Players.Value.Text" Text="@ConnectedPlayersCountValueText" />
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPIntermission.Players.Separator.Text" Text="/" />
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPIntermission.Players.Value.Text" Text="@MaxNumPlayersValueText" />
+              </Children>
+            </ListPanel>
+          </Children>
+        </ListPanel>
+      </Children>
+    </Widget>
+  </Window>
+</Prefab>

--- a/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
+++ b/Alliance.Common/Core/Configuration/Models/DefaultConfig.cs
@@ -148,6 +148,8 @@ namespace Alliance.Common.Core.Configuration.Models
 		public bool EnableRaceRestrictionOnStuff = true;
 		[ConfigProperty(true, "Authorize Poll", "Authorize everyone to use the GameMode menu when in Lobby.", category: "Advanced settings")]
 		public bool AuthorizePoll = false;
+		[ConfigProperty(true, "Loop current mode with native vote", "At match end, keep the current game mode and use native intermission votes for map and factions (top voted choices are picked).", category: "Advanced settings")]
+		public bool LoopCurrentModeWithNativeVote = false;
 
 		public DefaultConfig()
 		{

--- a/Alliance.Common/Core/Utils/Factions.cs
+++ b/Alliance.Common/Core/Utils/Factions.cs
@@ -10,12 +10,11 @@ namespace Alliance.Common.Core.Utils
 	/// </summary>
 	public class Factions
 	{
-		public List<string> NativeCultures = new List<string>() { "vlandia", "battania", "empire", "sturgia", "aserai", "khuzait" };
 		public Dictionary<string, BasicCultureObject> AvailableCultures;
 		public List<string> OrderedCultureKeys;
 
 		private static readonly Factions instance = new Factions();
-		public static Factions Instance { get { return instance; } }
+		public static Factions Instance => instance;
 
 		static Factions()
 		{

--- a/Alliance.Common/Extensions/IHandlerRegister.cs
+++ b/Alliance.Common/Extensions/IHandlerRegister.cs
@@ -11,4 +11,17 @@ namespace Alliance.Common.Extensions
     {
         void Register(NetworkMessageHandlerRegisterer reg);
     }
+
+    /// <summary>
+    /// Implement this interface for handlers whose lifetime must exceed the mission's.
+    /// Unlike <see cref="IHandlerRegister"/>, implementations are registered once (via
+    /// ClientGlobalAutoHandler / ServerGlobalAutoHandler) and are never unregistered, since
+    /// they may need to keep working after mission behaviors have been removed
+    /// (e.g. native post-mission intermission voting).
+    /// /!\ Do not use directly on a MissionBehavior as it will cause unwanted instantiation.
+    /// </summary>
+    public interface IGlobalHandlerRegister
+    {
+        void Register(NetworkMessageHandlerRegisterer reg);
+    }
 }

--- a/Alliance.Common/Extensions/NativeIntermissionVote/NetworkMessages/FromServer/ClearNativeIntermissionVoteItems.cs
+++ b/Alliance.Common/Extensions/NativeIntermissionVote/NetworkMessages/FromServer/ClearNativeIntermissionVoteItems.cs
@@ -1,0 +1,33 @@
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer
+{
+	/// <summary>
+	/// Clears native intermission vote items on clients before the server broadcasts its custom vote pool.
+	/// TaleWorlds native item messages only append items and update vote counts by index.
+	/// </summary>
+	[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+	public sealed class ClearNativeIntermissionVoteItems : GameNetworkMessage
+	{
+		protected override void OnWrite()
+		{
+		}
+
+		protected override bool OnRead()
+		{
+			return true;
+		}
+
+		protected override MultiplayerMessageFilter OnGetLogFilter()
+		{
+			return MultiplayerMessageFilter.Administration;
+		}
+
+		protected override string OnGetLogFormat()
+		{
+			return "Clear native intermission vote items";
+		}
+	}
+}
+

--- a/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
+++ b/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
@@ -25,11 +25,6 @@ namespace Alliance.Common.GameModes.BattleRoyale
 			ModOptions.BRZoneLifeTime = 300;
 		}
 
-		public override List<SceneInfo> GetAvailableMaps()
-		{
-			return base.GetAvailableMaps();
-		}
-
 		public override List<OptionType> GetAvailableNativeOptions()
 		{
 			return new List<OptionType>
@@ -44,7 +39,6 @@ namespace Alliance.Common.GameModes.BattleRoyale
 			return new List<string>
 			{
 				nameof(Config.BRZoneLifeTime),
-				nameof(Config.LoopCurrentModeWithNativeVote),
 				nameof(Config.AllowCustomBody),
 				nameof(Config.RandomizeAppearance),
 				nameof(Config.ShowFlagMarkers),

--- a/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
+++ b/Alliance.Common/GameModes/BattleRoyale/BRGameModeSettings.cs
@@ -44,6 +44,7 @@ namespace Alliance.Common.GameModes.BattleRoyale
 			return new List<string>
 			{
 				nameof(Config.BRZoneLifeTime),
+				nameof(Config.LoopCurrentModeWithNativeVote),
 				nameof(Config.AllowCustomBody),
 				nameof(Config.RandomizeAppearance),
 				nameof(Config.ShowFlagMarkers),

--- a/Alliance.Common/GameModes/Story/Actions/ActionFactory.cs
+++ b/Alliance.Common/GameModes/Story/Actions/ActionFactory.cs
@@ -51,6 +51,11 @@ namespace Alliance.Common.GameModes.Story.Actions
 			return new StartScenarioAction();
 		}
 
+		public virtual EndScenarioAction EndScenarioAction()
+		{
+			return new EndScenarioAction();
+		}
+
 		public virtual SpawnAgentAction SpawnAgentAction()
 		{
 			return new SpawnAgentAction();

--- a/Alliance.Common/GameModes/Story/Actions/EndScenarioAction.cs
+++ b/Alliance.Common/GameModes/Story/Actions/EndScenarioAction.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Alliance.Common.GameModes.Story.Actions
+{
+	/// <summary>
+	/// Action marking the end of a scenario flow.
+	/// The concrete runtime implementation decides which post-match transition should be started.
+	/// </summary>
+	[Serializable]
+	public class EndScenarioAction : ActionBase
+	{
+		public override void Execute() { }
+	}
+}
+
+

--- a/Alliance.Server/Core/GameModeStarter.cs
+++ b/Alliance.Server/Core/GameModeStarter.cs
@@ -1,8 +1,19 @@
 ﻿using Alliance.Common.Core.Configuration;
+using Alliance.Common.Core.Configuration.Models;
 using Alliance.Common.GameModes;
 using Alliance.Common.GameModes.Lobby;
 using NetworkMessages.FromServer;
 using System.Threading;
+using Alliance.Common.Extensions.PlayerSpawn.Models;
+using Alliance.Common.GameModes.Battle;
+using Alliance.Common.GameModes.BattleRoyale;
+using Alliance.Common.GameModes.Captain;
+using Alliance.Common.GameModes.CvC;
+using Alliance.Common.GameModes.Duel;
+using Alliance.Common.GameModes.PvC;
+using Alliance.Common.GameModes.Siege;
+using Alliance.Common.GameModes.Story;
+using Alliance.Server.Extensions.NativeIntermissionVote;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.DedicatedCustomServer;
@@ -53,10 +64,32 @@ namespace Alliance.Server.Core
 
 		private void EndMissionThenStartMission(GameModeSettings gameModeSettings)
 		{
+			MissionListener missionListener = new MissionListener();
+			missionListener.SetGameModeSettings(gameModeSettings);
+			EndMissionWithListener(missionListener, logAgentUsage: true);
+		}
+
+		internal void EndMissionWithListener(IMissionListener listener, bool logAgentUsage = false)
+		{
+			PrepareCurrentMissionForEnd(logAgentUsage);
+			DisableNativeIntermissionVotes();
+
+			Mission.Current.AddListener(listener);
+			EndingCurrentMissionThenStartingNewMission = true;
+			DedicatedCustomServerSubModule.Instance.ServerSideIntermissionManager.EndMission();
+		}
+
+		private void PrepareCurrentMissionForEnd(bool logAgentUsage = false)
+		{
+			if (Mission.Current == null)
+			{
+				return;
+			}
+
 			// Try to stop everyone from using objects to prevent crash
-			Log("Scene=" + Mission.Current?.SceneName, LogLevel.Debug);
-			Log("NB Agents=" + Mission.Current?.Agents.Count, LogLevel.Debug);
-			foreach (MissionObject missionObj in Mission.Current?.MissionObjects)
+			Log("Scene=" + Mission.Current.SceneName, LogLevel.Debug);
+			Log("NB Agents=" + Mission.Current.Agents.Count, LogLevel.Debug);
+			foreach (MissionObject missionObj in Mission.Current.MissionObjects)
 			{
 				if (missionObj is UsableMachine machine)
 				{
@@ -64,36 +97,27 @@ namespace Alliance.Server.Core
 					machine.Disable();
 				}
 			}
-			foreach (Agent agent in Mission.Current?.AllAgents)
+
+			foreach (Agent agent in Mission.Current.AllAgents)
 			{
 				agent.SetMortalityState(Agent.MortalityState.Invulnerable);
-				//UsableMissionObject missionObject = agent.CurrentlyUsedGameObject;
-				//if (missionObject != null)
-				//{
-				//    Log("agent using " + missionObject?.GameEntity?.Name, 0, Debug.DebugColor.Blue);
-				//    agent.StopUsingGameObject();
-				//    Log("agent now using " + agent.CurrentlyUsedGameObject?.GameEntity?.Name, 0, Debug.DebugColor.Blue);
-				//    missionObject.SetDisabled();
-				//}
-				//agent.AIStateFlags = Agent.AIStateFlag.Alarmed;
-				//agent.SetScriptedCombatFlags(Agent.AISpecialCombatModeFlags.None);
-				//agent.DisableScriptedMovement();
-				//agent.ClearTargetFrame();
-				//agent.Detachment?.RemoveAgent(agent);
-				Log($"{agent.Name} using {agent.CurrentlyUsedGameObject?.GameEntity.Name} - flag : {agent.AIStateFlags}  | {agent.GetScriptedCombatFlags()}", LogLevel.Debug);
+				if (logAgentUsage)
+				{
+					Log($"{agent.Name} using {agent.CurrentlyUsedGameObject?.GameEntity.Name} - flag : {agent.AIStateFlags}  | {agent.GetScriptedCombatFlags()}", LogLevel.Debug);
+				}
 			}
+		}
 
-			MissionListener missionListener = new MissionListener();
-			Mission.Current.AddListener(missionListener);
-			MultiplayerIntermissionVotingManager.Instance.IsCultureVoteEnabled = false;
-			MultiplayerIntermissionVotingManager.Instance.IsMapVoteEnabled = false;
-			EndingCurrentMissionThenStartingNewMission = true;
-			missionListener.SetGameModeSettings(gameModeSettings);
-			DedicatedCustomServerSubModule.Instance.ServerSideIntermissionManager.EndMission();
+		private static void DisableNativeIntermissionVotes()
+		{
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			votingManager.IsCultureVoteEnabled = false;
+			votingManager.IsMapVoteEnabled = false;
 		}
 
 		public void ApplyGameModeSettings(GameModeSettings gameModeSettings)
 		{
+			PlayerSpawnMenu.Instance.Clear();
 			ConfigManager.Instance.ApplyNativeOptions(gameModeSettings.TWOptions);
 			ConfigManager.Instance.ApplyModOptions(gameModeSettings.ModOptions);
 			SyncMultiplayerOptionsToClients();
@@ -101,6 +125,12 @@ namespace Alliance.Server.Core
 
 		public bool StartMissionOnly(GameModeSettings gameModeSettings)
 		{
+			if (gameModeSettings == null)
+			{
+				Log("StartMissionOnly called with null settings.", LogLevel.Error);
+				return false;
+			}
+
 			if (!MissionIsRunning)
 			{
 				ApplyGameModeSettings(gameModeSettings);
@@ -120,21 +150,86 @@ namespace Alliance.Server.Core
 			StartMission(lobby);
 		}
 
-		public GameModeStarter()
+		/// <summary>
+		/// Starts the configured post-match transition.
+		/// Defaults to Lobby, or runs the configured intermission flow when enabled.
+		/// </summary>
+		public void StartPostMatchTransition()
 		{
+			string map = OptionType.Map.GetStrValue();
+			string culture1 = OptionType.CultureTeam1.GetStrValue();
+			string culture2 = OptionType.CultureTeam2.GetStrValue();
+
+			if (EndingCurrentMissionThenStartingNewMission)
+			{
+				return;
+			}
+
+			if (Config.Instance.LoopCurrentModeWithNativeVote)
+			{
+				try
+				{
+					GameModeSettings currentGameModeSettings = CreateSettingsFromCurrentOptions();
+					if (NativeIntermissionVoteService.TryStart(this, currentGameModeSettings))
+					{
+						return;
+					}
+
+					Log("Native intermission vote could not be started. Falling back to Lobby.", LogLevel.Warning);
+				}
+				catch
+				{
+					Log("Failed to start native intermission vote. Falling back to Lobby.", LogLevel.Warning);
+				}
+			}
+
+			StartLobby(map, culture1, culture2);
+		}
+
+
+		public GameModeSettings CreateSettingsFromCurrentOptions()
+		{
+			string gameType = OptionType.GameType.GetStrValue();
+			GameModeSettings gameModeSettings;
+
+			switch (gameType)
+			{
+				case "CaptainX": gameModeSettings = new CaptainGameModeSettings(); break;
+				case "BattleX": gameModeSettings = new BattleGameModeSettings(); break;
+				case "SiegeX": gameModeSettings = new SiegeGameModeSettings(); break;
+				case "DuelX": gameModeSettings = new DuelGameModeSettings(); break;
+				case "Scenario": gameModeSettings = new ScenarioGameModeSettings(); break;
+				case "PvC": gameModeSettings = new PvCGameModeSettings(); break;
+				case "CvC": gameModeSettings = new CvCGameModeSettings(); break;
+				case "BattleRoyale": gameModeSettings = new BRGameModeSettings(); break;
+				case "Lobby": gameModeSettings = new LobbyGameModeSettings(); break;
+				default:
+					Log($"Unsupported game type '{gameType}' for loop transition. Falling back to Lobby.", LogLevel.Warning);
+					gameModeSettings = new LobbyGameModeSettings();
+					break;
+			}
+
+			gameModeSettings.TWOptions = ConfigManager.Instance.GetNativeOptionsCopy();
+			gameModeSettings.ModOptions = ConfigManager.Instance.GetModOptionsCopy();
+			return gameModeSettings;
 		}
 	}
 
-	public class MissionListener : IMissionListener
+	internal class MissionListener : IMissionListener
 	{
 		public void SetGameModeSettings(GameModeSettings gameModeSettings)
 		{
 			_gameModeSettings = gameModeSettings;
 		}
 
+		public void SetUseCurrentOptionsForNextMission()
+		{
+			_useCurrentOptionsForNextMission = true;
+		}
+
 		public void OnEndMission()
 		{
-			new Thread(new ParameterizedThreadStart(StartMissionThread.ThreadProc)).Start(_gameModeSettings);
+			new Thread(new ParameterizedThreadStart(StartMissionThread.ThreadProc)).Start(new StartMissionThread.StartMissionRequest(_gameModeSettings, _useCurrentOptionsForNextMission));
 			Mission.Current.RemoveListener(this);
 		}
 
@@ -166,20 +261,38 @@ namespace Alliance.Server.Core
 		{
 		}
 
-		public MissionListener()
-		{
-		}
-
 		private GameModeSettings _gameModeSettings;
+		private bool _useCurrentOptionsForNextMission;
 	}
 
 	internal class StartMissionThread
 	{
-		public static void ThreadProc(object gameModeSettings)
+		public class StartMissionRequest
 		{
+			public readonly GameModeSettings GameModeSettings;
+			public readonly bool UseCurrentOptionsForNextMission;
+
+			public StartMissionRequest(GameModeSettings gameModeSettings, bool useCurrentOptionsForNextMission)
+			{
+				GameModeSettings = gameModeSettings;
+				UseCurrentOptionsForNextMission = useCurrentOptionsForNextMission;
+			}
+		}
+
+		public static void ThreadProc(object requestObj)
+		{
+			StartMissionRequest request = requestObj as StartMissionRequest;
 			Thread.Sleep(1000);
 			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
-			GameModeStarter.Instance.StartMissionOnly((GameModeSettings)gameModeSettings);
+
+			if (request?.UseCurrentOptionsForNextMission == true)
+			{
+				GameModeSettings nextSettings = GameModeStarter.Instance.CreateSettingsFromCurrentOptions();
+				GameModeStarter.Instance.StartMissionOnly(nextSettings);
+				return;
+			}
+
+			GameModeStarter.Instance.StartMissionOnly(request?.GameModeSettings);
 		}
 
 		public StartMissionThread()

--- a/Alliance.Server/Core/GameModeStarter.cs
+++ b/Alliance.Server/Core/GameModeStarter.cs
@@ -43,10 +43,10 @@ namespace Alliance.Server.Core
 		{
 			GameNetwork.BeginBroadcastModuleEvent();
 			GameNetwork.WriteMessage(new MultiplayerOptionsInitial());
-			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients, null);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients);
 			GameNetwork.BeginBroadcastModuleEvent();
 			GameNetwork.WriteMessage(new MultiplayerOptionsImmediate());
-			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients, null);
+			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.IncludeUnsynchronizedClients);
 		}
 
 		public void StartMission(GameModeSettings gameModeSettings)
@@ -66,12 +66,12 @@ namespace Alliance.Server.Core
 		{
 			MissionListener missionListener = new MissionListener();
 			missionListener.SetGameModeSettings(gameModeSettings);
-			EndMissionWithListener(missionListener, logAgentUsage: true);
+			EndMissionWithListener(missionListener);
 		}
 
-		internal void EndMissionWithListener(IMissionListener listener, bool logAgentUsage = false)
+		internal void EndMissionWithListener(IMissionListener listener)
 		{
-			PrepareCurrentMissionForEnd(logAgentUsage);
+			PrepareCurrentMissionForEnd();
 			DisableNativeIntermissionVotes();
 
 			Mission.Current.AddListener(listener);
@@ -79,7 +79,7 @@ namespace Alliance.Server.Core
 			DedicatedCustomServerSubModule.Instance.ServerSideIntermissionManager.EndMission();
 		}
 
-		private void PrepareCurrentMissionForEnd(bool logAgentUsage = false)
+		private void PrepareCurrentMissionForEnd()
 		{
 			if (Mission.Current == null)
 			{
@@ -101,10 +101,6 @@ namespace Alliance.Server.Core
 			foreach (Agent agent in Mission.Current.AllAgents)
 			{
 				agent.SetMortalityState(Agent.MortalityState.Invulnerable);
-				if (logAgentUsage)
-				{
-					Log($"{agent.Name} using {agent.CurrentlyUsedGameObject?.GameEntity.Name} - flag : {agent.AIStateFlags}  | {agent.GetScriptedCombatFlags()}", LogLevel.Debug);
-				}
 			}
 		}
 
@@ -222,19 +218,10 @@ namespace Alliance.Server.Core
 			_gameModeSettings = gameModeSettings;
 		}
 
-		public void SetUseCurrentOptionsForNextMission()
-		{
-			_useCurrentOptionsForNextMission = true;
-		}
-
 		public void OnEndMission()
 		{
-			new Thread(new ParameterizedThreadStart(StartMissionThread.ThreadProc)).Start(new StartMissionThread.StartMissionRequest(_gameModeSettings, _useCurrentOptionsForNextMission));
+			new Thread(StartMissionThread.ThreadProc).Start(new StartMissionThread.StartMissionRequest(_gameModeSettings, _useCurrentOptionsForNextMission));
 			Mission.Current.RemoveListener(this);
-		}
-
-		public void OnInitialDeploymentPlanMade(BattleSideEnum battleSide, bool isFirstPlan)
-		{
 		}
 
 		public void OnMissionModeChange(MissionMode oldMissionMode, bool atStart)

--- a/Alliance.Server/Core/ServerGlobalAutoHandler.cs
+++ b/Alliance.Server/Core/ServerGlobalAutoHandler.cs
@@ -1,0 +1,56 @@
+using Alliance.Common.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using static Alliance.Common.Utilities.Logger;
+using static TaleWorlds.MountAndBlade.GameNetwork;
+
+namespace Alliance.Server.Core
+{
+    /// <summary>
+    /// Discovers and registers all IGlobalHandlerRegister implementations once per game session.
+    /// Unlike ServerAutoHandler, this is not tied to the mission lifecycle (not a MissionBehavior):
+    /// handlers registered here remain active even after mission behaviors are removed.
+    /// Call Initialize() once, typically from SubModule.OnGameInitializationFinished.
+    /// </summary>
+    public static class ServerGlobalAutoHandler
+    {
+        private static bool _initialized;
+
+        public static void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            try
+            {
+                NetworkMessageHandlerRegisterer reg = new NetworkMessageHandlerRegisterer(NetworkMessageHandlerRegisterer.RegisterMode.Add);
+                int handlerCount = 0;
+                IEnumerable<Type> handlerTypes = Assembly.GetExecutingAssembly()
+                                           .GetTypes()
+                                           .Where(t => t.GetInterfaces().Contains(typeof(IGlobalHandlerRegister)) && !t.IsAbstract);
+
+                foreach (Type type in handlerTypes)
+                {
+                    if (Activator.CreateInstance(type) is IGlobalHandlerRegister handler)
+                    {
+                        handler.Register(reg);
+                        handlerCount++;
+                    }
+                }
+
+                _initialized = true;
+                Log($"Alliance - Successfully registered {handlerCount} global server handlers", LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                Log($"Alliance - Error while registering global server handlers", LogLevel.Error);
+                Log(ex.ToString(), LogLevel.Error);
+            }
+        }
+    }
+}
+

--- a/Alliance.Server/Extensions/NativeIntermissionVote/Behaviors/NativeIntermissionVoteMissionListener.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/Behaviors/NativeIntermissionVoteMissionListener.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote.Behaviors
+{
+	/// <summary>
+	/// Triggers the native intermission vote after mission close, when clients are back in LobbyGameStateCustomGameClient.
+	/// </summary>
+	internal class NativeIntermissionVoteMissionListener : IMissionListener
+	{
+		public void OnEndMission()
+		{
+			Mission.Current?.RemoveListener(this);
+			new Thread(NativeIntermissionVoteService.RunVoteAndRestartMission).Start();
+		}
+
+		public void OnInitialDeploymentPlanMade(BattleSideEnum battleSide, bool isFirstPlan) { }
+		public void OnMissionModeChange(MissionMode oldMissionMode, bool atStart) { }
+		public void OnResetMission() { }
+		public void OnEquipItemsFromSpawnEquipmentBegin(Agent agent, Agent.CreationType creationType) { }
+		public void OnEquipItemsFromSpawnEquipment(Agent agent, Agent.CreationType creationType) { }
+		public void OnConversationCharacterChanged() { }
+		public void OnDeploymentPlanMade(Team team, bool isFirstPlan) { }
+	}
+}
+

--- a/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
@@ -1,0 +1,325 @@
+using Alliance.Common.GameModes;
+using Alliance.Common.GameModes.Story;
+using Alliance.Common.GameModes.Story.Models;
+using Alliance.Server.Core;
+using Alliance.Server.Extensions.NativeIntermissionVote.Behaviors;
+using Alliance.Server.Extensions.NativeIntermissionVote.NetworkMessages;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using static Alliance.Common.Utilities.Logger;
+using static TaleWorlds.MountAndBlade.MultiplayerOptions;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote
+{
+	/// <summary>
+	/// Handles the custom timeline for looping the current game mode through TaleWorlds native intermission votes.
+	/// </summary>
+	internal static class NativeIntermissionVoteService
+	{
+		private const float MapVoteDurationSeconds = 15f;
+		private const float CultureVoteDurationSeconds = 15f;
+		private const float IntermissionUpdateTickSeconds = 0.5f;
+		private const int WaitForLobbyStateMilliseconds = 2000;
+		private const int WaitBeforeMissionStartMilliseconds = 1000;
+		private const string ScenarioGameType = "Scenario";
+
+		private static readonly List<string> DefaultCultureVotePool = new List<string>
+		{
+			"khuzait",
+			"aserai",
+			"battania",
+			"vlandia",
+			"sturgia",
+			"empire"
+		};
+		private static readonly Dictionary<string, ScenarioVoteCandidate> ScenarioVoteCandidatesByVoteId = new Dictionary<string, ScenarioVoteCandidate>();
+		private static bool _currentVoteIsScenario;
+
+		/// <summary>
+		/// Tries to start the native intermission vote flow.
+		/// Returns false when the flow cannot be prepared and caller should use its fallback transition.
+		/// </summary>
+		internal static bool TryStart(GameModeStarter gameModeStarter, GameModeSettings currentGameModeSettings)
+		{
+			MissionLobbyComponent missionLobby = Mission.Current?.GetMissionBehavior<MissionLobbyComponent>();
+			if (missionLobby == null)
+			{
+				Log("Native intermission loop requested but MissionLobbyComponent is missing.", LogLevel.Warning);
+				return false;
+			}
+
+			if (missionLobby.CurrentMultiplayerState == MissionLobbyComponent.MultiplayerGameState.Ending)
+			{
+				return true;
+			}
+
+			_currentVoteIsScenario = IsScenario(currentGameModeSettings);
+
+			if (!PrepareVote(currentGameModeSettings, _currentVoteIsScenario))
+			{
+				return false;
+			}
+
+			gameModeStarter.EndMissionWithListener(new NativeIntermissionVoteMissionListener());
+			Log("Ending mission — native vote will run after mission closes, when clients are in lobby state.");
+			return true;
+		}
+
+		/// <summary>
+		/// Prepares the native voting manager before mission end, without broadcasting vote items yet.
+		/// Clients receive items only after returning to LobbyGameStateCustomGameClient.
+		/// </summary>
+		private static bool PrepareVote(GameModeSettings currentGameModeSettings, bool isScenarioVote)
+		{
+			if (currentGameModeSettings == null)
+			{
+				Log("Native intermission vote preparation failed: current game mode settings are null.", LogLevel.Error);
+				return false;
+			}
+
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			if (votingManager == null)
+			{
+				Log("Native intermission vote preparation failed: MultiplayerIntermissionVotingManager is missing.", LogLevel.Error);
+				return false;
+			}
+
+			votingManager.InitialGameType = OptionType.GameType.GetStrValue();
+			votingManager.IsAutomatedBattleSwitchingEnabled = true;
+			votingManager.IsMapVoteEnabled = true;
+			votingManager.IsCultureVoteEnabled = !isScenarioVote;
+			votingManager.IsDisableMapVoteOverride = false;
+			votingManager.IsDisableCultureVoteOverride = false;
+			votingManager.IsMapSelectedByAdmin = false;
+
+			return PrepareVoteItems(votingManager, currentGameModeSettings, isScenarioVote);
+		}
+
+
+		/// <summary>
+		/// Runs after the mission has closed. At this point clients are in lobby state and can display the native vote UI.
+		/// </summary>
+		public static void RunVoteAndRestartMission()
+		{
+			// Give clients time to finish mission unload and enter lobby state.
+			Thread.Sleep(WaitForLobbyStateMilliseconds);
+
+			MultiplayerIntermissionVotingManager votingManager = MultiplayerIntermissionVotingManager.Instance;
+			bool isScenarioVote = _currentVoteIsScenario;
+
+			// Re-enable voting and sync native manager values.
+			votingManager.IsMapVoteEnabled = true;
+			votingManager.IsCultureVoteEnabled = !isScenarioVote;
+			NativeIntermissionVoteMsg.SyncVotingManagerValuesToAllPeers();
+
+			NativeIntermissionVoteMsg.SendVoteItemsToAllPeers(votingManager);
+
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMapVote;
+			Log($"Native vote timeline - state -> CountingForMapVote for {MapVoteDurationSeconds}s");
+			RunIntermissionCountdown(MultiplayerIntermissionState.CountingForMapVote, MapVoteDurationSeconds);
+
+			if (!isScenarioVote)
+			{
+				votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForCultureVote;
+				Log($"Native vote timeline - state -> CountingForCultureVote for {CultureVoteDurationSeconds}s");
+				RunIntermissionCountdown(MultiplayerIntermissionState.CountingForCultureVote, CultureVoteDurationSeconds);
+			}
+
+			Log($"Native vote timeline - sorting votes. Maps={votingManager.MapVoteItems.Count} Cultures={votingManager.CultureVoteItems.Count}", LogLevel.Debug);
+			if (isScenarioVote)
+			{
+				StartVotedScenario(votingManager);
+				return;
+			}
+
+			votingManager.SortVotesAndPickBest();
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMission;
+
+			string selectedMap = OptionType.Map.GetStrValue();
+			string selectedCulture1 = OptionType.CultureTeam1.GetStrValue();
+			string selectedCulture2 = OptionType.CultureTeam2.GetStrValue();
+			Log($"Native vote timeline - state -> CountingForMission | selectedMap={selectedMap} | culture1={selectedCulture1} | culture2={selectedCulture2}");
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+
+			GameModeSettings nextSettings = GameModeStarter.Instance.CreateSettingsFromCurrentOptions();
+			nextSettings.TWOptions[OptionType.Map] = selectedMap;
+			nextSettings.TWOptions[OptionType.CultureTeam1] = selectedCulture1;
+			nextSettings.TWOptions[OptionType.CultureTeam2] = selectedCulture2;
+
+			Thread.Sleep(WaitBeforeMissionStartMilliseconds);
+			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+			GameModeStarter.Instance.StartMissionOnly(nextSettings);
+		}
+
+		private static bool PrepareVoteItems(MultiplayerIntermissionVotingManager votingManager, GameModeSettings currentGameModeSettings, bool isScenarioVote)
+		{
+			Log($"Vote setup - gameType={OptionType.GameType.GetStrValue()} | currentState={votingManager.CurrentVoteState} | mapsEnabled={votingManager.IsMapVoteEnabled} | culturesEnabled={votingManager.IsCultureVoteEnabled}", LogLevel.Debug);
+			Log($"Vote setup - current map={OptionType.Map.GetStrValue()} | cultures={OptionType.CultureTeam1.GetStrValue()} vs {OptionType.CultureTeam2.GetStrValue()}", LogLevel.Debug);
+
+			List<string> cultureVotePool = votingManager.CultureVoteItems.Select(item => item.Id).Distinct().ToList();
+			if (cultureVotePool.Count < 3)
+			{
+				cultureVotePool = new List<string>(DefaultCultureVotePool);
+			}
+
+			votingManager.ClearVotes();
+			votingManager.ClearItems();
+			ScenarioVoteCandidatesByVoteId.Clear();
+
+			if (isScenarioVote)
+			{
+				return PrepareScenarioVoteItems(votingManager);
+			}
+
+			List<string> availableMaps = currentGameModeSettings.GetAvailableMaps().Select(scene => scene.Name).Distinct().Take(MultiplayerIntermissionVotingManager.MaxAllowedMapCount).ToList();
+			Log($"Vote setup - preparing {availableMaps.Count} map candidates.", LogLevel.Debug);
+			for (int i = 0; i < availableMaps.Count; i++)
+			{
+				votingManager.MapVoteItems.Add(new IntermissionVoteItem(availableMaps[i], i));
+				Log($"Vote setup - map[{i}]={availableMaps[i]}", LogLevel.Debug);
+			}
+
+			Log($"Vote setup - preparing {cultureVotePool.Count} culture candidates.", LogLevel.Debug);
+			for (int i = 0; i < cultureVotePool.Count; i++)
+			{
+				votingManager.CultureVoteItems.Add(new IntermissionVoteItem(cultureVotePool[i], i));
+				Log($"Vote setup - culture[{i}]={cultureVotePool[i]}", LogLevel.Debug);
+			}
+
+			return availableMaps.Count > 0;
+		}
+
+		private static bool PrepareScenarioVoteItems(MultiplayerIntermissionVotingManager votingManager)
+		{
+			ScenarioManager.Instance.RefreshAvailableScenarios();
+
+			HashSet<string> usedVoteIds = new HashSet<string>();
+			List<Scenario> scenarios = ScenarioManager.Instance.AvailableScenario ?? new List<Scenario>();
+			foreach (Scenario scenario in scenarios)
+			{
+				if (scenario?.Acts == null)
+				{
+					continue;
+				}
+
+				for (int actIndex = 0; actIndex < scenario.Acts.Count; actIndex++)
+				{
+					Act act = scenario.Acts[actIndex];
+					if (act == null || string.IsNullOrEmpty(act.MapID))
+					{
+						continue;
+					}
+
+					string voteId = CreateScenarioVoteId(scenario, act, actIndex, usedVoteIds);
+					int itemIndex = votingManager.MapVoteItems.Count;
+					votingManager.MapVoteItems.Add(new IntermissionVoteItem(voteId, itemIndex));
+					ScenarioVoteCandidatesByVoteId[voteId] = new ScenarioVoteCandidate(scenario, act);
+					Log($"Vote setup - scenario[{itemIndex}]={voteId} | map={act.MapID}", LogLevel.Debug);
+				}
+			}
+
+			Log($"Vote setup - culture vote disabled for Scenario game mode. Prepared {ScenarioVoteCandidatesByVoteId.Count} scenario candidates.", LogLevel.Debug);
+			return ScenarioVoteCandidatesByVoteId.Count > 0;
+		}
+
+		private static string CreateScenarioVoteId(Scenario scenario, Act act, int actIndex, HashSet<string> usedVoteIds)
+		{
+			string baseVoteId = $"{scenario.Name.LocalizedText} - {act.Name.LocalizedText}";
+			if (string.IsNullOrWhiteSpace(baseVoteId) || baseVoteId == " - ")
+			{
+				baseVoteId = $"{scenario.Id} - Act {actIndex + 1}";
+			}
+
+			string voteId = baseVoteId;
+			if (usedVoteIds.Contains(voteId))
+			{
+				voteId = $"{baseVoteId} [{scenario.Id}:{actIndex + 1}]";
+			}
+
+			int duplicateIndex = 2;
+			while (usedVoteIds.Contains(voteId))
+			{
+				voteId = $"{baseVoteId} [{scenario.Id}:{actIndex + 1}:{duplicateIndex++}]";
+			}
+
+			usedVoteIds.Add(voteId);
+			return voteId;
+		}
+
+		private static void StartVotedScenario(MultiplayerIntermissionVotingManager votingManager)
+		{
+			ScenarioVoteCandidate candidate = GetWinningScenarioCandidate(votingManager);
+			if (candidate == null)
+			{
+				Log("Native scenario vote failed: no winning scenario candidate found. Falling back to Lobby.", LogLevel.Error);
+				GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+				GameModeStarter.Instance.StartLobby(OptionType.Map.GetStrValue(), OptionType.CultureTeam1.GetStrValue(), OptionType.CultureTeam2.GetStrValue());
+				return;
+			}
+
+			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMission;
+			OptionType.Map.SetValue(candidate.Act.MapID);
+			Log($"Native vote timeline - state -> CountingForMission | selectedScenario={candidate.Scenario.Name.LocalizedText} | act={candidate.Act.Name.LocalizedText} | map={candidate.Act.MapID}");
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+
+			Thread.Sleep(WaitBeforeMissionStartMilliseconds);
+			GameModeStarter.Instance.EndingCurrentMissionThenStartingNewMission = false;
+			candidate.Act.ActSettings.TWOptions[OptionType.Map] = candidate.Act.MapID;
+			ScenarioManager.Instance.StartScenario(candidate.Scenario, candidate.Act);
+		}
+
+		private static ScenarioVoteCandidate GetWinningScenarioCandidate(MultiplayerIntermissionVotingManager votingManager)
+		{
+			IntermissionVoteItem winningItem = votingManager.MapVoteItems.OrderByDescending(item => item.VoteCount).FirstOrDefault();
+			if (winningItem == null)
+			{
+				return null;
+			}
+
+			if (winningItem.VoteCount <= 0)
+			{
+				winningItem = votingManager.MapVoteItems[MBRandom.RandomInt(0, votingManager.MapVoteItems.Count)];
+			}
+
+			ScenarioVoteCandidatesByVoteId.TryGetValue(winningItem.Id, out ScenarioVoteCandidate candidate);
+			return candidate;
+		}
+
+		private static void RunIntermissionCountdown(MultiplayerIntermissionState state, float durationSeconds)
+		{
+			float remaining = durationSeconds;
+			while (remaining > 0f)
+			{
+				NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(state, remaining);
+				float step = remaining > IntermissionUpdateTickSeconds ? IntermissionUpdateTickSeconds : remaining;
+				Thread.Sleep((int)(step * 1000f));
+				remaining -= step;
+			}
+
+			NativeIntermissionVoteMsg.SendIntermissionUpdateToAllPeers(state, 0f);
+		}
+
+		private static bool IsScenario(GameModeSettings gameModeSettings)
+		{
+			return gameModeSettings?.TWOptions[OptionType.GameType]?.ToString() == ScenarioGameType;
+		}
+
+		private sealed class ScenarioVoteCandidate
+		{
+			public readonly Scenario Scenario;
+			public readonly Act Act;
+
+			public ScenarioVoteCandidate(Scenario scenario, Act act)
+			{
+				Scenario = scenario;
+				Act = act;
+			}
+		}
+	}
+}
+
+
+

--- a/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/NativeIntermissionVoteService.cs
@@ -1,9 +1,11 @@
+using Alliance.Common.Core.Utils;
 using Alliance.Common.GameModes;
 using Alliance.Common.GameModes.Story;
 using Alliance.Common.GameModes.Story.Models;
 using Alliance.Server.Core;
 using Alliance.Server.Extensions.NativeIntermissionVote.Behaviors;
 using Alliance.Server.Extensions.NativeIntermissionVote.NetworkMessages;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,15 +28,6 @@ namespace Alliance.Server.Extensions.NativeIntermissionVote
 		private const int WaitBeforeMissionStartMilliseconds = 1000;
 		private const string ScenarioGameType = "Scenario";
 
-		private static readonly List<string> DefaultCultureVotePool = new List<string>
-		{
-			"khuzait",
-			"aserai",
-			"battania",
-			"vlandia",
-			"sturgia",
-			"empire"
-		};
 		private static readonly Dictionary<string, ScenarioVoteCandidate> ScenarioVoteCandidatesByVoteId = new Dictionary<string, ScenarioVoteCandidate>();
 		private static bool _currentVoteIsScenario;
 
@@ -136,6 +129,7 @@ namespace Alliance.Server.Extensions.NativeIntermissionVote
 			}
 
 			votingManager.SortVotesAndPickBest();
+			ApplyDynamicCultureVoteResult(votingManager);
 			votingManager.CurrentVoteState = MultiplayerIntermissionState.CountingForMission;
 
 			string selectedMap = OptionType.Map.GetStrValue();
@@ -159,12 +153,6 @@ namespace Alliance.Server.Extensions.NativeIntermissionVote
 			Log($"Vote setup - gameType={OptionType.GameType.GetStrValue()} | currentState={votingManager.CurrentVoteState} | mapsEnabled={votingManager.IsMapVoteEnabled} | culturesEnabled={votingManager.IsCultureVoteEnabled}", LogLevel.Debug);
 			Log($"Vote setup - current map={OptionType.Map.GetStrValue()} | cultures={OptionType.CultureTeam1.GetStrValue()} vs {OptionType.CultureTeam2.GetStrValue()}", LogLevel.Debug);
 
-			List<string> cultureVotePool = votingManager.CultureVoteItems.Select(item => item.Id).Distinct().ToList();
-			if (cultureVotePool.Count < 3)
-			{
-				cultureVotePool = new List<string>(DefaultCultureVotePool);
-			}
-
 			votingManager.ClearVotes();
 			votingManager.ClearItems();
 			ScenarioVoteCandidatesByVoteId.Clear();
@@ -174,6 +162,8 @@ namespace Alliance.Server.Extensions.NativeIntermissionVote
 				return PrepareScenarioVoteItems(votingManager);
 			}
 
+			List<string> cultureVotePool = GetDynamicCultureVotePool();
+
 			List<string> availableMaps = currentGameModeSettings.GetAvailableMaps().Select(scene => scene.Name).Distinct().Take(MultiplayerIntermissionVotingManager.MaxAllowedMapCount).ToList();
 			Log($"Vote setup - preparing {availableMaps.Count} map candidates.", LogLevel.Debug);
 			for (int i = 0; i < availableMaps.Count; i++)
@@ -182,14 +172,131 @@ namespace Alliance.Server.Extensions.NativeIntermissionVote
 				Log($"Vote setup - map[{i}]={availableMaps[i]}", LogLevel.Debug);
 			}
 
-			Log($"Vote setup - preparing {cultureVotePool.Count} culture candidates.", LogLevel.Debug);
+			Log($"Vote setup - preparing {cultureVotePool.Count} culture candidates from Factions.", LogLevel.Debug);
 			for (int i = 0; i < cultureVotePool.Count; i++)
 			{
 				votingManager.CultureVoteItems.Add(new IntermissionVoteItem(cultureVotePool[i], i));
 				Log($"Vote setup - culture[{i}]={cultureVotePool[i]}", LogLevel.Debug);
 			}
 
-			return availableMaps.Count > 0;
+			return availableMaps.Count > 0 && cultureVotePool.Count > 0;
+		}
+
+		private static List<string> GetDynamicCultureVotePool()
+		{
+			Factions factions;
+			try
+			{
+				factions = Factions.Instance;
+				factions.RefreshAvailablecultures();
+			}
+			catch (Exception exception)
+			{
+				Log($"Vote setup - failed to refresh available cultures through Factions: {exception.Message}", LogLevel.Error);
+				return GetCurrentCultureVotePoolFallback();
+			}
+
+			IEnumerable<string> cultureIds = null;
+			if (factions.OrderedCultureKeys != null && factions.OrderedCultureKeys.Count > 0)
+			{
+				cultureIds = factions.OrderedCultureKeys;
+			}
+			else if (factions.AvailableCultures != null)
+			{
+				cultureIds = factions.AvailableCultures.Keys;
+			}
+
+			List<string> cultureVotePool = new List<string>();
+			if (cultureIds != null)
+			{
+				foreach (string cultureId in cultureIds)
+				{
+					if (string.IsNullOrWhiteSpace(cultureId))
+					{
+						continue;
+					}
+
+					if (factions.AvailableCultures != null && !factions.AvailableCultures.ContainsKey(cultureId))
+					{
+						continue;
+					}
+
+					AddCultureToVotePool(cultureVotePool, cultureId);
+				}
+			}
+
+			if (cultureVotePool.Count == 0)
+			{
+				Log("Vote setup - Factions returned no available culture; falling back to current team cultures.", LogLevel.Warning);
+				return GetCurrentCultureVotePoolFallback();
+			}
+
+			return cultureVotePool;
+		}
+
+		private static List<string> GetCurrentCultureVotePoolFallback()
+		{
+			List<string> cultureVotePool = new List<string>();
+			AddCultureToVotePool(cultureVotePool, OptionType.CultureTeam1.GetStrValue());
+			AddCultureToVotePool(cultureVotePool, OptionType.CultureTeam2.GetStrValue());
+
+			if (cultureVotePool.Count == 0)
+			{
+				Log("Vote setup - no culture candidate could be loaded for native intermission vote.", LogLevel.Error);
+			}
+
+			return cultureVotePool;
+		}
+
+		private static void AddCultureToVotePool(List<string> cultureVotePool, string cultureId)
+		{
+			if (!string.IsNullOrWhiteSpace(cultureId) && !cultureVotePool.Contains(cultureId))
+			{
+				cultureVotePool.Add(cultureId);
+			}
+		}
+
+		private static void ApplyDynamicCultureVoteResult(MultiplayerIntermissionVotingManager votingManager)
+		{
+			if (!votingManager.IsCultureVoteEnabled)
+			{
+				return;
+			}
+
+			List<IntermissionVoteItem> cultureVoteItems = votingManager.CultureVoteItems.ToList();
+			if (cultureVoteItems.Count == 0)
+			{
+				Log("Native vote timeline - no culture vote item available; keeping current culture options.", LogLevel.Warning);
+				return;
+			}
+
+			cultureVoteItems.Sort((culture1, culture2) => -culture1.VoteCount.CompareTo(culture2.VoteCount));
+
+			string selectedCulture1;
+			string selectedCulture2;
+			if (cultureVoteItems[0].VoteCount > 0)
+			{
+				selectedCulture1 = cultureVoteItems[0].Id;
+				selectedCulture2 = cultureVoteItems.Count > 1 ? cultureVoteItems[1].Id : cultureVoteItems[0].Id;
+
+				int totalVoteCount = cultureVoteItems.Select(item => item.VoteCount).Sum();
+				if (totalVoteCount > 0 && 10 * cultureVoteItems[0].VoteCount >= 7 * totalVoteCount)
+				{
+					selectedCulture2 = selectedCulture1;
+				}
+			}
+			else
+			{
+				Random random = new Random();
+				selectedCulture1 = cultureVoteItems[random.Next(0, cultureVoteItems.Count)].Id;
+				selectedCulture2 = cultureVoteItems[random.Next(0, cultureVoteItems.Count)].Id;
+			}
+
+			// TaleWorlds' no-vote culture fallback is hardcoded to the six native cultures.
+			// Re-apply the final culture result from CultureVoteItems so Factions-loaded cultures stay valid.
+			OptionType.CultureTeam1.SetValue(selectedCulture1);
+			OptionType.CultureTeam2.SetValue(selectedCulture2);
+			Log($"Native vote timeline - dynamic culture selection | culture1={selectedCulture1} | culture2={selectedCulture2}", LogLevel.Debug);
 		}
 
 		private static bool PrepareScenarioVoteItems(MultiplayerIntermissionVotingManager votingManager)

--- a/Alliance.Server/Extensions/NativeIntermissionVote/NetworkMessages/NativeIntermissionVoteMsg.cs
+++ b/Alliance.Server/Extensions/NativeIntermissionVote/NetworkMessages/NativeIntermissionVoteMsg.cs
@@ -1,0 +1,98 @@
+using Alliance.Common.Extensions.NativeIntermissionVote.NetworkMessages.FromServer;
+using NetworkMessages.FromServer;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+using static Alliance.Common.Utilities.Logger;
+
+namespace Alliance.Server.Extensions.NativeIntermissionVote.NetworkMessages
+{
+	/// <summary>
+	/// Server-side message sender for the native intermission vote UI.
+	/// Uses TaleWorlds native intermission messages, plus one Alliance reset message to rebuild client vote lists safely.
+	/// </summary>
+	internal static class NativeIntermissionVoteMsg
+	{
+		public static void SyncVotingManagerValuesToAllPeers()
+		{
+			SendToAllClients(new UpdateIntermissionVotingManagerValues());
+		}
+
+		public static void SendVoteItemsToAllPeers(MultiplayerIntermissionVotingManager votingManager)
+		{
+			Log($"Vote broadcast - {votingManager.MapVoteItems.Count} maps, {votingManager.CultureVoteItems.Count} cultures.", LogLevel.Debug);
+			ResetVoteItemsOnAllPeers();
+
+			foreach (IntermissionVoteItem item in votingManager.MapVoteItems)
+			{
+				SendMapItemAddedToAllPeers(item.Id);
+				SendMapVoteCountChangedToAllPeers(item.Index, item.VoteCount);
+			}
+
+			foreach (IntermissionVoteItem item in votingManager.CultureVoteItems)
+			{
+				SendCultureItemAddedToAllPeers(item.Id);
+				SendCultureVoteCountChangedToAllPeers(item.Index, item.VoteCount);
+			}
+		}
+
+		public static void SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState state, float timer)
+		{
+			SendToAllClients(new MultiplayerIntermissionUpdate(state, timer));
+		}
+
+		private static void ResetVoteItemsOnAllPeers()
+		{
+			// Native item messages are append-only and vote counts are later updated by index.
+			// CountingForMission makes MPIntermissionVM clear its displayed lists, while the custom
+			// message clears MultiplayerIntermissionVotingManager items on the client.
+			SendIntermissionUpdateToAllPeers(MultiplayerIntermissionState.CountingForMission, 0f);
+			ClearVoteItemsOnAllPeers();
+		}
+
+		private static void SendMapItemAddedToAllPeers(string mapId)
+		{
+			Log($"Native vote broadcast - map item added: {mapId}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionMapItemAdded(mapId));
+		}
+
+		private static void ClearVoteItemsOnAllPeers()
+		{
+			Log("Native vote broadcast - clearing vote items on clients.", LogLevel.Debug);
+			SendToAllClients(new ClearNativeIntermissionVoteItems());
+		}
+
+		private static void SendCultureItemAddedToAllPeers(string cultureId)
+		{
+			Log($"Native vote broadcast - culture item added: {cultureId}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionCultureItemAdded(cultureId));
+		}
+
+		private static void SendMapVoteCountChangedToAllPeers(int mapItemIndex, int voteCount)
+		{
+			Log($"Native vote broadcast - map vote count changed: index={mapItemIndex} votes={voteCount}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionMapItemVoteCountChanged(mapItemIndex, voteCount));
+		}
+
+		private static void SendCultureVoteCountChangedToAllPeers(int cultureItemIndex, int voteCount)
+		{
+			Log($"Native vote broadcast - culture vote count changed: index={cultureItemIndex} votes={voteCount}", LogLevel.Debug);
+			SendToAllClients(new MultiplayerIntermissionCultureItemVoteCountChanged(cultureItemIndex, voteCount));
+		}
+
+		private static void SendToAllClients(GameNetworkMessage message)
+		{
+			foreach (NetworkCommunicator peer in GameNetwork.NetworkPeers)
+			{
+				if (peer.IsServerPeer)
+				{
+					continue;
+				}
+
+				GameNetwork.BeginModuleEventAsServer(peer);
+				GameNetwork.WriteMessage(message);
+				GameNetwork.EndModuleEventAsServer();
+			}
+		}
+	}
+}
+

--- a/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
+++ b/Alliance.Server/GameModes/BattleRoyale/Behaviors/BRBehavior.cs
@@ -116,7 +116,7 @@ namespace Alliance.Server.GameModes.BattleRoyale.Behaviors
 					CommonAdminMsg.SendNotificationToAll(loseMessage);
 					Log(loseMessage);
 				}
-				GameModeStarter.Instance.StartLobby(MultiplayerOptions.OptionType.Map.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+				GameModeStarter.Instance.StartPostMatchTransition();
 				_gameEnded = true;
 			}
 		}

--- a/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
+++ b/Alliance.Server/GameModes/CaptainX/Behaviors/ALMissionMultiplayerFlagDomination.cs
@@ -828,10 +828,10 @@ namespace Alliance.Server.GameModes.CaptainX.Behaviors
 
 		private void OnPostRoundEnd()
 		{
-			// Go back to Lobby on match end
+			// Start the configured post-match transition
 			if (RoundController.IsMatchEnding)
 			{
-				GameModeStarter.Instance.StartLobby(MultiplayerOptions.OptionType.Map.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(), MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+				GameModeStarter.Instance.StartPostMatchTransition();
 			}
 			else if (UseGold())
 			{

--- a/Alliance.Server/GameModes/Story/Actions/Server_ActionFactory.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_ActionFactory.cs
@@ -24,6 +24,11 @@ namespace Alliance.Server.GameModes.Story.Actions
 			return new Server_StartScenarioAction();
 		}
 
+		public override EndScenarioAction EndScenarioAction()
+		{
+			return new Server_EndScenarioAction();
+		}
+
 		public override SpawnAgentAction SpawnAgentAction()
 		{
 			return new Server_SpawnAgentAction();

--- a/Alliance.Server/GameModes/Story/Actions/Server_EndScenarioAction.cs
+++ b/Alliance.Server/GameModes/Story/Actions/Server_EndScenarioAction.cs
@@ -1,0 +1,18 @@
+using Alliance.Common.GameModes.Story.Actions;
+using Alliance.Server.Core;
+
+namespace Alliance.Server.GameModes.Story.Actions
+{
+	/// <summary>
+	/// Server-side implementation for ending a scenario and starting the configured post-match transition.
+	/// </summary>
+	public class Server_EndScenarioAction : EndScenarioAction
+	{
+		public override void Execute()
+		{
+			GameModeStarter.Instance.StartPostMatchTransition();
+		}
+	}
+}
+
+

--- a/Alliance.Server/GameModes/Story/Behaviors/ScenarioBehavior.cs
+++ b/Alliance.Server/GameModes/Story/Behaviors/ScenarioBehavior.cs
@@ -8,6 +8,7 @@ using NetworkMessages.FromServer;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using HarmonyLib;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -22,7 +23,7 @@ namespace Alliance.Server.GameModes.Story.Behaviors
 	/// Server-side base behavior for scenario game mode.
 	/// Responsible for updating scenario state.
 	/// </summary>
-	public class ScenarioBehavior : MissionMultiplayerGameModeBase, IMissionBehavior
+	public class ScenarioBehavior : MissionMultiplayerGameModeBase
 	{
 		public Scenario Scenario => ScenarioManagerServer.Instance.CurrentScenario;
 		public Act Act => ScenarioManagerServer.Instance.CurrentAct;
@@ -42,10 +43,6 @@ namespace Alliance.Server.GameModes.Story.Behaviors
 		public bool EnableStateChange { get; private set; }
 
 		private float _checkStateDt;
-
-		public ScenarioBehavior()
-		{
-		}
 
 		public override void OnBehaviorInitialize()
 		{

--- a/Alliance.Server/GameModes/Story/ScenarioManagerServer.cs
+++ b/Alliance.Server/GameModes/Story/ScenarioManagerServer.cs
@@ -31,7 +31,7 @@ namespace Alliance.Server.GameModes.Story
 			{
 				Act currentAct = currentScenario.Acts[actIndex];
 				StartScenario(currentScenario, currentAct, state);
-				Log($"Starting scenario \"{currentScenario?.Name.LocalizedText}\" at act {actIndex + 1}", LogLevel.Debug);
+				Log($"Starting scenario \"{currentScenario.Name.LocalizedText}\" at act {actIndex + 1}", LogLevel.Debug);
 			}
 			else
 			{
@@ -44,14 +44,18 @@ namespace Alliance.Server.GameModes.Story
 			base.StartScenario(scenario, act, state);
 
 			// If LoadMap enabled or current map is different from act map, start a complete new mission with act settings
-			if (act.LoadMap || (act.MapID != null && OptionType.Map.GetValueText() != act.MapID))
+			if (Mission.Current == null || act.LoadMap || (act.MapID != null && OptionType.Map.GetValueText() != act.MapID))
 			{
 				// If currently in a Scenario, prevent it from changing state
-				Mission.Current.GetMissionBehavior<ScenarioBehavior>()?.StopScenario();
+				Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.StopScenario();
+				if (act.MapID != null)
+				{
+					act.ActSettings.TWOptions[OptionType.Map] = act.MapID;
+				}
 
 				// Log the start
 				string log2 = $"Starting scenario \"{scenario.Name.LocalizedText}\" - Act \"{act.Name.LocalizedText}\" on map {act.MapID}...";
-				Log(log2, LogLevel.Information);
+				Log(log2);
 				SendMessageToAll(log2);
 				GameModeStarter.Instance.StartMission(act.ActSettings);
 				return;
@@ -59,7 +63,7 @@ namespace Alliance.Server.GameModes.Story
 
 			// Log the start
 			string log = $"Starting scenario \"{scenario.Name.LocalizedText}\" - Act \"{act.Name.LocalizedText}\"...";
-			Log(log, LogLevel.Information);
+			Log(log);
 			SendMessageToAll(log);
 
 			// Else, just apply new act settings to the current mission
@@ -91,7 +95,7 @@ namespace Alliance.Server.GameModes.Story
 		/// </summary>
 		public void SyncActState(ActState newState)
 		{
-			float stateRemainingTime = (float)(Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.TimerComponent.GetRemainingTime(false));
+			float stateRemainingTime = Mission.Current?.GetMissionBehavior<ScenarioBehavior>()?.TimerComponent.GetRemainingTime(false) ?? 0f;
 			GameNetwork.BeginBroadcastModuleEvent();
 			GameNetwork.WriteMessage(new UpdateScenarioMessage(newState, MissionTime.Now.NumberOfTicks, MathF.Ceiling(stateRemainingTime)));
 			GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);

--- a/Alliance.Server/SubModule.cs
+++ b/Alliance.Server/SubModule.cs
@@ -3,6 +3,7 @@ using Alliance.Common.Core.Security;
 using Alliance.Common.Extensions.AnimationPlayer;
 using Alliance.Common.Patch;
 using Alliance.Common.Utilities;
+using Alliance.Server.Core;
 using Alliance.Server.Core.Configuration;
 using Alliance.Server.Core.Security;
 using Alliance.Server.GameModes.BattleRoyale;
@@ -53,6 +54,7 @@ namespace Alliance.Server
 			AnimationSystem.Instance.Init();
 
 			SceneList.Initialize();
+			ServerGlobalAutoHandler.Initialize();
 
 			Log("Alliance behaviors initialized.", LogLevel.Debug);
 		}
@@ -71,7 +73,6 @@ namespace Alliance.Server
 		{
 			// Load ExtendedCharacter.xml into usable ExtendedCharacterObjects
 			ExtendedXMLLoader.Init();
-
 			ScenarioManagerServer.Initialize();
 		}
 


### PR DESCRIPTION
# Native post-match intermission voting

## Summary
  
  Adds an optional post-match flow using TaleWorlds native intermission voting. When `LoopCurrentModeWithNativeVote` is enabled, the server can keep the current game mode running and let players vote for the next map and, when applicable, cultures. If the vote flow cannot start, the server falls back to the existing Lobby transition.

## Changes

- Added `LoopCurrentModeWithNativeVote` advanced config option.
- Added `GameModeStarter.StartPostMatchTransition()` and updated BR/CaptainX match-end logic to use it.
- Added the `NativeIntermissionVote` server extension to prepare vote items, run the intermission timeline, broadcast native vote messages, and restart the selected game mode.
- Added a client-side reset message/handler to clear stale native vote items before broadcasting custom vote candidates.
- Added special handling for `Scenario` mode:
    - map vote only;
    - culture vote disabled;
    - vote candidates represent `Scenario + Act`, not only physical maps, because several scenarios can share the same `MapID`.
- Added `EndScenarioAction`, allowing scenarios to explicitly trigger the configured post-match transition.
- Updated `ScenarioManagerServer` to better support starting scenarios from intermission/lobby state.
- Added `.github/agents/tw-native-explorer.agent.md` to help explore decompiled TaleWorlds native code, and documented custom agents in `AGENTS.md`.
- Added a new `IGlobalHandlerRegister` handler type (in `Alliance.Common/Extensions/IHandlerRegister.cs`) for network message handlers whose lifetime must exceed the mission's, discovered and registered once per game session by the new `ClientGlobalAutoHandler` / `ServerGlobalAutoHandler`.
- `NativeIntermissionVoteHandler` uses this new handler type, since native intermission voting runs after mission behaviors are removed.

## Global handler registration

  Network message handlers usually implement `IHandlerRegister` and are discovered/registered by `ClientAutoHandler` / `ServerAutoHandler`, which are themselves `MissionBehavior`s. This ties their handler's lifetime to the mission: registered on `OnBehaviorInitialize`, unregistered on `OnRemoveBehavior`.
  Some flows, like native intermission voting, keep running after mission behaviors have already been removed. A handler tied to the mission lifecycle would be unregistered too early and miss incoming messages.
  For these cases, a handler can instead implement `IGlobalHandlerRegister`. These handlers are discovered the same way (reflection over the executing assembly), but by `ClientGlobalAutoHandler` / `ServerGlobalAutoHandler`, which are plain static classes (not `MissionBehavior`s) initialized once via `Initialize()` from `SubModule` (e.g. `OnGameInitializationFinished`). They register their handlers a single time for the whole game session and are never unregistered.
  In short: use `IHandlerRegister` for handlers scoped to a mission; use `IGlobalHandlerRegister` for handlers that must survive beyond it.

## AGENTS.md

  Added `AGENTS.md` at the repo root, a guide for AI coding agents working on this codebase. It covers the project layout (the five Bannerlord-target projects and what each one is responsible for), the build system (`BANNERLORD_GAME_DIR`, post-build copy, `net472`/`net6.0` split for `Alliance.Common`), the checklist for adding a new game mode, the network message pattern (`DefineGameNetworkMessageTypeForMod`, `OnWrite`/`OnRead`), handler registration (`IHandlerRegister`/`IGlobalHandlerRegister`), the configuration system, Harmony patch conventions, and logging. It also documents the `tw-native-explorer` custom agent used to browse decompiled TaleWorlds native code.

## Scenario migration note
  
  Existing scenarios that should use this new post-match flow need to add `EndScenarioAction` to the relevant `ActionsOnActCompleted` list.
  Without this action, existing scenario completion remains action-driven and will not automatically start the new vote/lobby transition.
